### PR TITLE
La til applikasjonsnavn og BasicQos på kanal (konfigurerbart)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,8 @@
     <jackson-databind-nullable.version>0.2.2</jackson-databind-nullable.version>
     <fiks-io-asice-handler.version>1.1.1</fiks-io-asice-handler.version>
     <scribejava.version>8.3.1</scribejava.version>
+    <testcontainers.version>1.17.1</testcontainers.version>
+    <mockserver.version>5.13.2</mockserver.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -76,6 +78,13 @@
         <version>${junit-jupiter.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers-bom</artifactId>
+        <version>${testcontainers.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -241,8 +250,19 @@
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
+    <resources>
+      <resource>
+        <filtering>true</filtering>
+        <directory>${basedir}/src/main/resources</directory>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/src/main/java/no/ks/fiks/io/client/Meta.java
+++ b/src/main/java/no/ks/fiks/io/client/Meta.java
@@ -1,0 +1,24 @@
+package no.ks.fiks.io.client;
+
+import java.io.IOException;
+import java.util.Properties;
+
+public class Meta {
+    /**
+     * Inneholder gjeldende versjonsnummer
+     */
+    public static String VERSJON;
+    private static final String VERSJON_PROP_FIL = "fiks-io-version.properties";
+
+    private static final String PROP_VERSJON = "versjon";
+
+    static {
+        Properties properties = new Properties();
+        try {
+            properties.load(Meta.class.getClassLoader().getResourceAsStream(VERSJON_PROP_FIL));
+            VERSJON = properties.getProperty(PROP_VERSJON);
+        } catch (IOException e) {
+            throw new IllegalStateException(String.format("Kan ikke laste versjonsfil %s", VERSJON_PROP_FIL), e);
+        }
+    }
+}

--- a/src/main/java/no/ks/fiks/io/client/konfigurasjon/AmqpKonfigurasjon.java
+++ b/src/main/java/no/ks/fiks/io/client/konfigurasjon/AmqpKonfigurasjon.java
@@ -2,6 +2,7 @@ package no.ks.fiks.io.client.konfigurasjon;
 
 import lombok.Builder;
 import lombok.Data;
+import no.ks.fiks.io.client.Meta;
 import no.ks.fiks.io.client.model.MeldingId;
 
 import java.util.function.Predicate;
@@ -26,6 +27,17 @@ public class AmqpKonfigurasjon {
      * Ikke påkrevd. Det er her mulig å konfigurere et predikat som forteller om en spesifikk melding har blitt behandlet tidligere, slik at man unngår duplikat meldinger som ellers kan oppstå gjennom en amqp kobling, pga. nettverksbrudd eller lignende.
      */
     @Builder.Default private Predicate<MeldingId> meldingErBehandlet = m -> false;
+
+    /**
+     * Meta informasjon om klienten som skal motta meldinger
+     */
+    @Builder.Default private String applikasjonNavn = String.format("Fiks IO klient (Java) %s", Meta.VERSJON);
+
+    /**
+     * Hvor mange meldinger skal buffres ved mottak. Trenger stort sett ikke endres.
+     * Teknisk informasjon: brukes som AMQP QOS/prefetch- størrelse for konsumentsiden
+     */
+    @Builder.Default private int mottakBufferStorrelse = 10;
 
     /**
      * Konfigurasjon for prod.

--- a/src/main/resources/fiks-io-version.properties
+++ b/src/main/resources/fiks-io-version.properties
@@ -1,0 +1,1 @@
+versjon=${project.version}

--- a/src/test/java/no/ks/fiks/io/client/MetaTest.java
+++ b/src/test/java/no/ks/fiks/io/client/MetaTest.java
@@ -1,0 +1,12 @@
+package no.ks.fiks.io.client;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MetaTest {
+    @Test
+    void testLastVersjonnummer() {
+        assertNotNull(Meta.VERSJON);
+    }
+}


### PR DESCRIPTION
La til mulighet for å konfigurere qos/prefetch størrelse på konsument, samt la til konfigurerbart applikasjonsnavn (default til fiks-io-klient)
