### PR TITLE
Fjern vavr

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <fiks-dokumentlager-klient.version>1.9.0</fiks-dokumentlager-klient.version>
     <openapi-generator-maven-plugin.version>6.1.0</openapi-generator-maven-plugin.version>
     <slf4j.version>1.7.36</slf4j.version>
-    <fiks-io-send-klient.version>2.0.0</fiks-io-send-klient.version>
+    <fiks-io-send-klient.version>2.1.0</fiks-io-send-klient.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <spec.location>https://ks-no.github.io/api/</spec.location>
     <spec.name>fiksio-katalog-api-v1</spec.name>

--- a/src/main/java/no/ks/fiks/io/client/FiksIOHandler.java
+++ b/src/main/java/no/ks/fiks/io/client/FiksIOHandler.java
@@ -1,6 +1,5 @@
 package no.ks.fiks.io.client;
 
-import io.vavr.control.Option;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import no.ks.fiks.io.asice.AsicHandler;
@@ -14,6 +13,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.cert.X509Certificate;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -63,7 +63,7 @@ class FiksIOHandler implements Closeable {
         log.debug("Sender melding til \"{}\"", mottagerKontoId);
         return utsendingKlient.send(
             lagMeldingSpesifikasjon(request),
-            payload.isEmpty() ? Option.none() : Option.some(encrypt(payload, request.getMottakerKontoId())));
+            Optional.of(payload).filter(p -> ! p.isEmpty()).map(p -> encrypt(p, request.getMottakerKontoId())));
     }
 
     private MeldingSpesifikasjonApiModel lagMeldingSpesifikasjon(@NonNull MeldingRequest request) {
@@ -83,7 +83,7 @@ class FiksIOHandler implements Closeable {
         final UUID mottagerKontoId = meldingRequest.getMottakerKontoId()
             .getUuid();
         log.debug("Sender ferdig kryptert melding til \"{}\"", mottagerKontoId);
-        return utsendingKlient.send(lagMeldingSpesifikasjon(meldingRequest), Option.of(inputStream));
+        return utsendingKlient.send(lagMeldingSpesifikasjon(meldingRequest), Optional.of(inputStream));
     }
 
     private InputStream encrypt(@NonNull final List<Payload> payload, final KontoId kontoId) {

--- a/src/main/java/no/ks/fiks/io/client/SvarSender.java
+++ b/src/main/java/no/ks/fiks/io/client/SvarSender.java
@@ -1,7 +1,6 @@
 package no.ks.fiks.io.client;
 
 import com.google.common.collect.ImmutableMap;
-import io.vavr.control.Option;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
@@ -14,6 +13,7 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 import static java.util.Collections.singletonList;
@@ -32,14 +32,14 @@ public class SvarSender {
 
     public SendtMelding svar(String meldingType, List<Payload> payloads) {
         return SendtMelding.fromSendResponse(utsendingKlient.send(
-            fellesBuilder(meldingType).build(), payloads.isEmpty() ? Option.none() : Option.of(encrypt.apply(payloads))));
+            fellesBuilder(meldingType).build(), Optional.ofNullable(payloads).filter(p -> ! p.isEmpty()).map(encrypt)));
     }
 
     public SendtMelding svar(String meldingType, List<Payload> payloads, MeldingId klientMeldingId) {
         return SendtMelding.fromSendResponse(utsendingKlient.send(
             fellesBuilder(meldingType)
             .headere(ImmutableMap.of(Melding.HeaderKlientMeldingId, klientMeldingId.toString()))
-            .build(), payloads.isEmpty() ? Option.none() : Option.of(encrypt.apply(payloads))));
+            .build(), Optional.ofNullable(payloads).filter(p -> ! p.isEmpty()).map(encrypt)));
     }
 
     public SendtMelding svar(String meldingType, InputStream melding, String filnavn) {

--- a/src/main/java/no/ks/fiks/io/client/send/FiksIOSender.java
+++ b/src/main/java/no/ks/fiks/io/client/send/FiksIOSender.java
@@ -1,13 +1,13 @@
 package no.ks.fiks.io.client.send;
 
-import io.vavr.control.Option;
 import no.ks.fiks.io.klient.MeldingSpesifikasjonApiModel;
 import no.ks.fiks.io.klient.SendtMeldingApiModel;
 
 import java.io.Closeable;
 import java.io.InputStream;
+import java.util.Optional;
 
 public interface FiksIOSender extends Closeable {
 
-    SendtMeldingApiModel send(MeldingSpesifikasjonApiModel metadata, Option<InputStream> data);
+    SendtMeldingApiModel send(MeldingSpesifikasjonApiModel metadata, Optional<InputStream> data);
 }

--- a/src/main/java/no/ks/fiks/io/client/send/FiksIOSenderClientWrapper.java
+++ b/src/main/java/no/ks/fiks/io/client/send/FiksIOSenderClientWrapper.java
@@ -1,6 +1,5 @@
 package no.ks.fiks.io.client.send;
 
-import io.vavr.control.Option;
 import lombok.NonNull;
 import no.ks.fiks.io.klient.FiksIOUtsendingKlient;
 import no.ks.fiks.io.klient.MeldingSpesifikasjonApiModel;
@@ -8,6 +7,7 @@ import no.ks.fiks.io.klient.SendtMeldingApiModel;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 
 public class FiksIOSenderClientWrapper implements FiksIOSender {
 
@@ -18,7 +18,7 @@ public class FiksIOSenderClientWrapper implements FiksIOSender {
     }
 
     @Override
-    public SendtMeldingApiModel send(final MeldingSpesifikasjonApiModel metadata, final Option<InputStream> data) {
+    public SendtMeldingApiModel send(final MeldingSpesifikasjonApiModel metadata, final Optional<InputStream> data) {
         return utsendingKlient.send(metadata, data);
     }
 

--- a/src/test/java/no/ks/fiks/io/client/FiksIOHandlerTest.java
+++ b/src/test/java/no/ks/fiks/io/client/FiksIOHandlerTest.java
@@ -1,6 +1,5 @@
 package no.ks.fiks.io.client;
 
-import io.vavr.control.Option;
 import no.ks.fiks.io.asice.AsicHandler;
 import no.ks.fiks.io.client.model.*;
 import no.ks.fiks.io.client.send.FiksIOSender;
@@ -22,6 +21,7 @@ import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.ZipInputStream;
@@ -76,7 +76,7 @@ class FiksIOHandlerTest {
                     .toMillis())
                 .headere(meldingRequest.getHeadere())
                 .build();
-            when(utsendingKlient.send(isA(MeldingSpesifikasjonApiModel.class), isA(Option.class))).thenReturn(sendtMeldingApiModel);
+            when(utsendingKlient.send(isA(MeldingSpesifikasjonApiModel.class), isA(Optional.class))).thenReturn(sendtMeldingApiModel);
 
             final SendtMelding sendtMelding = fiksIOHandler.send(meldingRequest, Collections.emptyList());
             assertAll(
@@ -87,7 +87,7 @@ class FiksIOHandlerTest {
                     .toMillis())
             );
 
-            verify(utsendingKlient).send(isA(MeldingSpesifikasjonApiModel.class), eq(Option.none()));
+            verify(utsendingKlient).send(isA(MeldingSpesifikasjonApiModel.class), eq(Optional.empty()));
             verifyNoMoreInteractions(utsendingKlient);
             verifyNoInteractions(katalogHandler, asicHandler, x509Certificate);
         }
@@ -111,7 +111,7 @@ class FiksIOHandlerTest {
                     .toMillis())
                 .headere(meldingRequest.getHeadere())
                 .build();
-            when(utsendingKlient.send(isA(MeldingSpesifikasjonApiModel.class), isA(Option.class))).thenReturn(sendtMeldingApiModel);
+            when(utsendingKlient.send(isA(MeldingSpesifikasjonApiModel.class), isA(Optional.class))).thenReturn(sendtMeldingApiModel);
             when(katalogHandler.getPublicKey(eq(meldingRequest.getMottakerKontoId()))).thenReturn(x509Certificate);
             when(asicHandler.encrypt(same(x509Certificate), isA(List.class))).thenReturn(new ByteArrayInputStream(new byte[]{0, 1, 0, 1}));
 
@@ -125,7 +125,7 @@ class FiksIOHandlerTest {
                     .toMillis())
             );
             final ArgumentCaptor<MeldingSpesifikasjonApiModel> meldingRequestCaptor = ArgumentCaptor.forClass(MeldingSpesifikasjonApiModel.class);
-            verify(utsendingKlient).send(meldingRequestCaptor.capture(), isA(Option.class));
+            verify(utsendingKlient).send(meldingRequestCaptor.capture(), isA(Optional.class));
 
 
             verify(katalogHandler).getPublicKey(eq(meldingRequest.getMottakerKontoId()));
@@ -192,14 +192,14 @@ class FiksIOHandlerTest {
                     .toMillis())
                 .headere(Collections.emptyMap())
                 .build();
-            when(utsendingKlient.send(isA(MeldingSpesifikasjonApiModel.class), isA(Option.class))).thenReturn(sendtMeldingApiModel);
+            when(utsendingKlient.send(isA(MeldingSpesifikasjonApiModel.class), isA(Optional.class))).thenReturn(sendtMeldingApiModel);
 
             try (final InputStream dataStream = new ByteArrayInputStream("Innhold".getBytes())) {
                 final SendtMelding sendtMelding = fiksIOHandler.sendRaw(meldingRequest, dataStream);
                 assertNotNull(sendtMelding);
                 assertEquals(sendtMelding.getMeldingId().getUuid(), sendtMeldingApiModel.getMeldingId());
             }
-            verify(utsendingKlient).send(isA(MeldingSpesifikasjonApiModel.class), isA(Option.class));
+            verify(utsendingKlient).send(isA(MeldingSpesifikasjonApiModel.class), isA(Optional.class));
             verifyNoInteractions(katalogHandler, asicHandler, x509Certificate);
         }
     }

--- a/src/test/java/no/ks/fiks/io/client/SvarSenderTest.java
+++ b/src/test/java/no/ks/fiks/io/client/SvarSenderTest.java
@@ -1,7 +1,6 @@
 package no.ks.fiks.io.client;
 
 import com.google.common.collect.ImmutableMap;
-import io.vavr.control.Option;
 import no.ks.fiks.io.client.model.*;
 import no.ks.fiks.io.client.send.FiksIOSender;
 import no.ks.fiks.io.klient.MeldingSpesifikasjonApiModel;
@@ -21,7 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.Collections;
-import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.ZipInputStream;
@@ -59,7 +58,7 @@ class SvarSenderTest {
             final MottattMelding mottattMelding = createMottattMelding(buf, inputStream);
 
             final SvarSender svarSender = createSvarSender(buf, mottattMelding);
-            when(fiksIOSender.send(isA(MeldingSpesifikasjonApiModel.class), isA(Option.class)))
+            when(fiksIOSender.send(isA(MeldingSpesifikasjonApiModel.class), isA(Optional.class)))
                 .thenAnswer((Answer<SendtMeldingApiModel>) invocationOnMock -> {
                     MeldingSpesifikasjonApiModel meldingSpesifikasjonApiModel = invocationOnMock.getArgument(0);
                     return SendtMeldingApiModel.builder()
@@ -74,7 +73,7 @@ class SvarSenderTest {
             final SendtMelding sendtMelding = svarSender.svar(mottattMelding.getMeldingType());
             assertNotNull(sendtMelding);
             assertFalse(ackCompleted.get());
-            verify(fiksIOSender).send(isA(MeldingSpesifikasjonApiModel.class), isA(Option.class));
+            verify(fiksIOSender).send(isA(MeldingSpesifikasjonApiModel.class), isA(Optional.class));
             verifyNoMoreInteractions(fiksIOSender);
         }
     }
@@ -88,7 +87,7 @@ class SvarSenderTest {
             final MottattMelding mottattMelding = createMottattMelding(buf, inputStream);
             final MeldingId klientMeldingId = new MeldingId(UUID.randomUUID());
             final SvarSender svarSender = createSvarSender(buf, mottattMelding);
-            when(fiksIOSender.send(isA(MeldingSpesifikasjonApiModel.class), isA(Option.class)))
+            when(fiksIOSender.send(isA(MeldingSpesifikasjonApiModel.class), isA(Optional.class)))
                 .thenAnswer((Answer<SendtMeldingApiModel>) invocationOnMock -> {
                     MeldingSpesifikasjonApiModel meldingSpesifikasjonApiModel = invocationOnMock.getArgument(0);
                     return SendtMeldingApiModel.builder()
@@ -105,7 +104,7 @@ class SvarSenderTest {
             assertEquals(klientMeldingId, sendtMelding.getKlientMeldingId());
             assertNotNull(sendtMelding);
             assertFalse(ackCompleted.get());
-            verify(fiksIOSender).send(isA(MeldingSpesifikasjonApiModel.class), isA(Option.class));
+            verify(fiksIOSender).send(isA(MeldingSpesifikasjonApiModel.class), isA(Optional.class));
             verifyNoMoreInteractions(fiksIOSender);
         }
     }


### PR DESCRIPTION
Vavr var fint pre-java 11. Nå foretrekker vi å bruke Javas egne typer