### PR TITLE
FIKS-168 Tilpasninger for SB 3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-libPipelineMvnCentral(
+libPipelineMvnCentralJdk17(
     dtProjectId: "a2668fcd-8c97-47f8-9303-eaded61a5b10",
     componentTestProject: "fiks-io-klient-java-komponent-test"
 )

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>no.ks.fiks.pom</groupId>
     <artifactId>fiks-ekstern-super-pom</artifactId>
-    <version>1.0.20</version>
+    <version>1.0.21</version>
   </parent>
   <groupId>no.ks.fiks</groupId>
   <artifactId>fiks-io-klient-java</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>no.ks.fiks</groupId>
   <artifactId>fiks-io-klient-java</artifactId>
-  <version>2.0.14-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <name>FIKS IO Java-klient</name>
   <description>Klient for integrasjoner mot Fiks IO. Håndterer sending, mottak, kryptering, dekryptering og signering</description>
   <url>https://github.com/ks-no/fiks-io-klient-java</url>
@@ -22,15 +22,14 @@
     <rabbitmq-amqp-client.version>5.17.0</rabbitmq-amqp-client.version>
     <feign-form-version>3.8.0</feign-form-version>
     <fiks-feign-interceptors.version>1.1.3</fiks-feign-interceptors.version>
-    <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <difi-commons-asic.version>0.11.0</difi-commons-asic.version>
     <guava.version>31.1-jre</guava.version>
     <jackson.version>2.14.2</jackson.version>
     <download-maven-plugin.version>1.6.8</download-maven-plugin.version>
     <fiks-dokumentlager-klient.version>2.0.0</fiks-dokumentlager-klient.version>
     <openapi-generator-maven-plugin.version>6.5.0</openapi-generator-maven-plugin.version>
-    <slf4j.version>1.7.36</slf4j.version>
-    <fiks-io-send-klient.version>2.1.4</fiks-io-send-klient.version>
+    <slf4j.version>2.0.7</slf4j.version>
+    <fiks-io-send-klient.version>3.0.0</fiks-io-send-klient.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <spec.location>https://ks-no.github.io/api/</spec.location>
     <spec.name>fiksio-katalog-api-v1</spec.name>
@@ -39,7 +38,7 @@
     <logback.version>1.4.6</logback.version>
     <swagger-core-version>1.6.10</swagger-core-version>
     <kryptering.version>1.3.1</kryptering.version>
-    <java.version>11</java.version>
+    <java.version>17</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
@@ -54,6 +53,7 @@
     <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>
     <fiks-io-asice-handler.version>1.2.5</fiks-io-asice-handler.version>
     <scribejava.version>8.3.3</scribejava.version>
+    <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -210,9 +210,9 @@
       <version>${jackson-databind-nullable.version}</version>
     </dependency>
     <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>${javax.annotation-api.version}</version>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <version>${jakarta.annotation-api.version}</version>
     </dependency>
     <dependency>
       <groupId>com.github.scribejava</groupId>
@@ -291,6 +291,7 @@
                 <dateLibrary>java8</dateLibrary>
                 <feignVersion>10.x</feignVersion>
                 <java8>true</java8>
+                <useJakartaEe>true</useJakartaEe>
               </configOptions>
               <modelPackage>${project.groupId}.fiksio.client.api.katalog.model</modelPackage>
               <apiPackage>${project.groupId}.fiksio.client.api.katalog.api</apiPackage>

--- a/src/main/java/no/ks/fiks/io/client/FiksIOKlientFactory.java
+++ b/src/main/java/no/ks/fiks/io/client/FiksIOKlientFactory.java
@@ -20,6 +20,7 @@ import no.ks.fiks.io.client.model.KontoId;
 import no.ks.fiks.io.client.send.FiksIOSender;
 import no.ks.fiks.io.client.send.FiksIOSenderClientWrapper;
 import no.ks.fiks.io.klient.FiksIOUtsendingKlient;
+import no.ks.fiks.maskinporten.AccessTokenRequest;
 import no.ks.fiks.maskinporten.Maskinportenklient;
 import no.ks.fiks.maskinporten.MaskinportenklientProperties;
 
@@ -132,7 +133,7 @@ public class FiksIOKlientFactory {
         return Feign.builder()
             .decoder(new JacksonDecoder(objectMapper))
             .encoder(new JacksonEncoder(objectMapper))
-            .requestInterceptor(RequestInterceptors.accessToken(() -> maskinportenklient.getAccessToken(MASKINPORTEN_KS_SCOPE)))
+            .requestInterceptor(RequestInterceptors.accessToken(() -> maskinportenklient.getAccessToken(AccessTokenRequest.builder().scope(MASKINPORTEN_KS_SCOPE).build())))
             .requestInterceptor(RequestInterceptors.integrasjon(
                 konfigurasjon.getFiksIntegrasjonKonfigurasjon().getIntegrasjonId(),
                 konfigurasjon.getFiksIntegrasjonKonfigurasjon().getIntegrasjonPassord()))

--- a/src/test/java/no/ks/fiks/io/client/FiksIOHandlerTest.java
+++ b/src/test/java/no/ks/fiks/io/client/FiksIOHandlerTest.java
@@ -19,10 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.ZipInputStream;
 
@@ -44,7 +41,7 @@ class FiksIOHandlerTest {
     @Mock
     private X509Certificate x509Certificate;
 
-    private KontoId kontoId = new KontoId(UUID.randomUUID());
+    private final KontoId kontoId = new KontoId(UUID.randomUUID());
 
     private FiksIOHandler fiksIOHandler;
 
@@ -54,6 +51,7 @@ class FiksIOHandlerTest {
         this.fiksIOHandler = new FiksIOHandler(kontoId, utsendingKlient, katalogHandler, asicHandler, publicKeyProvider);
     }
 
+    @SuppressWarnings("unchecked")
     @Nested
     @DisplayName("Send")
     class Send {
@@ -72,7 +70,7 @@ class FiksIOHandlerTest {
                 .avsenderKontoId(UUID.randomUUID())
                 .mottakerKontoId(mottakerKontoId)
                 .meldingType("type")
-                .ttl(meldingRequest.getTtl()
+                .ttl(Objects.requireNonNull(meldingRequest.getTtl())
                     .toMillis())
                 .headere(meldingRequest.getHeadere())
                 .build();
@@ -169,6 +167,7 @@ class FiksIOHandlerTest {
         }
     }
 
+    @SuppressWarnings("unchecked")
     @Nested
     @DisplayName("Send rådata")
     class SendRaw {
@@ -188,7 +187,7 @@ class FiksIOHandlerTest {
                 .avsenderKontoId(UUID.randomUUID())
                 .mottakerKontoId(mottakerKontoId)
                 .meldingType(meldingsprotokoll)
-                .ttl(meldingRequest.getTtl()
+                .ttl(Objects.requireNonNull(meldingRequest.getTtl())
                     .toMillis())
                 .headere(Collections.emptyMap())
                 .build();

--- a/src/test/java/no/ks/fiks/io/client/SvarSenderTest.java
+++ b/src/test/java/no/ks/fiks/io/client/SvarSenderTest.java
@@ -28,6 +28,7 @@ import java.util.zip.ZipInputStream;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+@SuppressWarnings("unchecked")
 @DisplayName("SvarSender")
 @ExtendWith(MockitoExtension.class)
 class SvarSenderTest {


### PR DESCRIPTION
- Bump jackson-databind-nullable from 0.2.4 to 0.2.6
- Bump feign-version from 12.1 to 12.2
- Bump mockito.version from 5.1.1 to 5.2.0
- Bump maven-surefire-plugin from 3.0.0-M8 to 3.0.0
- Bump logback-classic from 1.4.5 to 1.4.6
- Bump amqp-client from 5.16.0 to 5.17.0
- Bump swagger-annotations from 1.6.9 to 1.6.10
- Bump fiks-ekstern-super-pom from 1.0.20 to 1.0.21
- Bump maskinporten-client from 2.1.5 to 3.0.0
- Bump dokumentlager-klient from 1.10.0 to 2.0.0
- Bump openapi-generator-maven-plugin from 6.3.0 to 6.5.0
- FIKS-168 diverse endringer for å fjerne litt warnings
- JDK 17
