### PR TITLE
Henter antallkonsumenter inn i konto objektet fra det oppdaterte api'et

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>no.ks.fiks.pom</groupId>
     <artifactId>fiks-ekstern-super-pom</artifactId>
-    <version>1.2.5</version>
+    <version>1.2.8</version>
   </parent>
   <groupId>no.ks.fiks</groupId>
   <artifactId>fiks-io-klient-java</artifactId>
@@ -37,21 +37,21 @@
     <fiks-io-asice-handler.version>2.2.0</fiks-io-asice-handler.version>
     <fiks-io-commons.version>2.0.3</fiks-io-commons.version>
     <fiks-io-send-klient.version>3.3.0</fiks-io-send-klient.version>
-    <fiks-maskinporten-client.version>3.3.1</fiks-maskinporten-client.version>
-    <guava.version>33.3.1-jre</guava.version>
+    <fiks-maskinporten-client.version>3.3.2</fiks-maskinporten-client.version>
+    <guava.version>33.4.0-jre</guava.version>
     <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>
     <jackson.version>2.18.2</jackson.version>
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
     <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
-    <junit-jupiter.version>5.11.3</junit-jupiter.version>
-    <kryptering.version>2.0.6</kryptering.version>
+    <junit-jupiter.version>5.11.4</junit-jupiter.version>
+    <kryptering.version>2.0.7</kryptering.version>
     <ks-commons-asic.version>1.0.2</ks-commons-asic.version>
-    <logback.version>1.5.12</logback.version>
+    <logback.version>1.5.15</logback.version>
     <lombok.version>1.18.36</lombok.version>
     <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
     <mockito.version>5.14.2</mockito.version>
     <openapi-generator-maven-plugin.version>7.10.0</openapi-generator-maven-plugin.version>
-    <rabbitmq-amqp-client.version>5.22.0</rabbitmq-amqp-client.version>
+    <rabbitmq-amqp-client.version>5.24.0</rabbitmq-amqp-client.version>
     <scribejava.version>8.3.3</scribejava.version>
     <slf4j.version>2.0.7</slf4j.version>
     <spec.postfix>json</spec.postfix>

--- a/pom.xml
+++ b/pom.xml
@@ -46,10 +46,10 @@
     <junit-jupiter.version>5.11.4</junit-jupiter.version>
     <kryptering.version>2.0.7</kryptering.version>
     <ks-commons-asic.version>1.0.2</ks-commons-asic.version>
-    <logback.version>1.5.15</logback.version>
+    <logback.version>1.5.16</logback.version>
     <lombok.version>1.18.36</lombok.version>
     <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
-    <mockito.version>5.14.2</mockito.version>
+    <mockito.version>5.15.2</mockito.version>
     <openapi-generator-maven-plugin.version>7.10.0</openapi-generator-maven-plugin.version>
     <rabbitmq-amqp-client.version>5.24.0</rabbitmq-amqp-client.version>
     <scribejava.version>8.3.3</scribejava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <enforcer.jdk.version>${java.version}</enforcer.jdk.version>
 
-    <commons-io.version>2.17.0</commons-io.version>
-    <download-maven-plugin.version>1.11.1</download-maven-plugin.version>
+    <commons-io.version>2.18.0</commons-io.version>
+    <download-maven-plugin.version>1.13.0</download-maven-plugin.version>
     <feign-form-version>3.8.0</feign-form-version>
     <feign-version>13.5</feign-version>
     <fiks-dokumentlager-klient.version>3.0.3</fiks-dokumentlager-klient.version>
@@ -40,17 +40,17 @@
     <fiks-maskinporten-client.version>3.3.1</fiks-maskinporten-client.version>
     <guava.version>33.3.1-jre</guava.version>
     <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>
-    <jackson.version>2.18.1</jackson.version>
+    <jackson.version>2.18.2</jackson.version>
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
     <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
     <junit-jupiter.version>5.11.3</junit-jupiter.version>
     <kryptering.version>2.0.6</kryptering.version>
     <ks-commons-asic.version>1.0.2</ks-commons-asic.version>
     <logback.version>1.5.12</logback.version>
-    <lombok.version>1.18.34</lombok.version>
+    <lombok.version>1.18.36</lombok.version>
     <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
     <mockito.version>5.14.2</mockito.version>
-    <openapi-generator-maven-plugin.version>7.9.0</openapi-generator-maven-plugin.version>
+    <openapi-generator-maven-plugin.version>7.10.0</openapi-generator-maven-plugin.version>
     <rabbitmq-amqp-client.version>5.22.0</rabbitmq-amqp-client.version>
     <scribejava.version>8.3.3</scribejava.version>
     <slf4j.version>2.0.7</slf4j.version>

--- a/src/main/java/no/ks/fiks/io/client/model/Konto.java
+++ b/src/main/java/no/ks/fiks/io/client/model/Konto.java
@@ -16,6 +16,7 @@ public class Konto {
     String kommuneNummer;
     boolean isGyldigAvsender;
     boolean isGyldigMottaker;
+    long antallKonsumenter;
 
     public static Konto fromKatalogModel(@NonNull KatalogKonto konto) {
         return Konto.builder()
@@ -27,6 +28,7 @@ public class Konto {
             .kommuneNummer(konto.getKommunenummer())
             .isGyldigAvsender(konto.getStatus().getGyldigAvsender())
             .isGyldigMottaker(konto.getStatus().getGyldigMottaker())
+            .antallKonsumenter(konto.getStatus().getAntallKonsumenter())
             .build();
     }
 }

--- a/src/test/java/no/ks/fiks/io/client/KatalogHandlerTest.java
+++ b/src/test/java/no/ks/fiks/io/client/KatalogHandlerTest.java
@@ -79,6 +79,7 @@ class KatalogHandlerTest {
                                      .fiksOrgNavn("OrgNavn")
                                      .isGyldigAvsender(true)
                                      .isGyldigMottaker(true)
+                                     .antallKonsumenter(0)
                                      .build();
             when(fiksIoKatalogApi.lookup(eq(sammensattIdentifikator), eq(meldingType), eq(sikkerhetsNiva))).thenReturn(new KatalogKonto().fiksOrgId(
                 konto.getFiksOrgId()
@@ -95,7 +96,8 @@ class KatalogHandlerTest {
                                                                                                                                                   .gyldigAvsender(
                                                                                                                                                       true)
                                                                                                                                                   .gyldigMottaker(
-                                                                                                                                                      true)));
+                                                                                                                                                      true)
+                                                                                                                                                  .antallKonsumenter(konto.getAntallKonsumenter())));
             final Optional<Konto> funnetKonto = katalogHandler.lookup(LookupRequest.builder()
                                                                                    .identifikator(new Identifikator(identifikatorType, identifikator))
                                                                                    .sikkerhetsNiva(sikkerhetsNiva)


### PR DESCRIPTION
Nå får man antallkonsumenter som del av status under konto objektet. 
[Se jira sak](https://ksfiks.atlassian.net/jira/software/c/projects/CR/boards/60?assignee=6020ff0ae7deee006913865f&selectedIssue=FO-183)