### PR TITLE
Bumps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,29 +33,29 @@
     <feign-form-version>3.8.0</feign-form-version>
     <feign-version>13.5</feign-version>
     <fiks-dokumentlager-klient.version>3.0.3</fiks-dokumentlager-klient.version>
-    <fiks-feign-interceptors.version>1.1.5</fiks-feign-interceptors.version>
+    <fiks-feign-interceptors.version>1.2.0</fiks-feign-interceptors.version>
     <fiks-io-asice-handler.version>2.2.0</fiks-io-asice-handler.version>
     <fiks-io-commons.version>2.0.3</fiks-io-commons.version>
     <fiks-io-send-klient.version>3.3.0</fiks-io-send-klient.version>
-    <fiks-maskinporten-client.version>3.3.2</fiks-maskinporten-client.version>
+    <fiks-maskinporten-client.version>3.4.0</fiks-maskinporten-client.version>
     <guava.version>33.4.0-jre</guava.version>
     <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>
     <jackson.version>2.18.2</jackson.version>
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
     <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
-    <junit-jupiter.version>5.11.4</junit-jupiter.version>
+    <junit-jupiter.version>5.12.0</junit-jupiter.version>
     <kryptering.version>2.0.7</kryptering.version>
     <ks-commons-asic.version>1.0.2</ks-commons-asic.version>
-    <logback.version>1.5.16</logback.version>
+    <logback.version>1.5.17</logback.version>
     <lombok.version>1.18.36</lombok.version>
     <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
     <mockito.version>5.15.2</mockito.version>
-    <openapi-generator-maven-plugin.version>7.10.0</openapi-generator-maven-plugin.version>
-    <rabbitmq-amqp-client.version>5.24.0</rabbitmq-amqp-client.version>
+    <openapi-generator-maven-plugin.version>7.11.0</openapi-generator-maven-plugin.version>
+    <rabbitmq-amqp-client.version>5.25.0</rabbitmq-amqp-client.version>
     <scribejava.version>8.3.3</scribejava.version>
     <slf4j.version>2.0.7</slf4j.version>
     <spec.postfix>json</spec.postfix>
-    <swagger-core-version>1.6.14</swagger-core-version>
+    <swagger-core-version>1.6.15</swagger-core-version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
- Bumps [ch.qos.logback:logback-classic](https://github.com/qos-ch/logback) from 1.5.16 to 1.5.17.
- Bumps [no.ks.fiks:maskinporten-client](https://github.com/ks-no/fiks-maskinporten) from 3.3.2 to 3.4.0.
- Bumps [org.junit:junit-bom](https://github.com/junit-team/junit5) from 5.11.4 to 5.12.0.
- Bumps [com.rabbitmq:amqp-client](https://github.com/rabbitmq/rabbitmq-java-client) from 5.24.0 to 5.25.0.
- Bumps org.openapitools:openapi-generator-maven-plugin from 7.10.0 to 7.11.0.
- Bumps [no.ks.fiks:feign-interceptors](https://github.com/ks-no/fiks-feign-interceptors) from 1.1.5 to 1.2.0.
- Bumps io.swagger:swagger-annotations from 1.6.14 to 1.6.15.
