### PR TITLE
Lagt inn støtte for klientKorrelansjonId.

### DIFF
--- a/src/main/java/no/ks/fiks/io/client/SvarSender.java
+++ b/src/main/java/no/ks/fiks/io/client/SvarSender.java
@@ -90,9 +90,9 @@ public class SvarSender {
         ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
 
         if (meldingSomSkalKvitteres.getKlientKorrelasjonId() != null &&
-            meldingSomSkalKvitteres.getKlientKorrelasjonId().getKlientKorrelasjonId() != null) {
+            meldingSomSkalKvitteres.getKlientKorrelasjonId().toString() != null) {
             builder.put(Melding.HeaderKlientKorrelasjonId,
-                meldingSomSkalKvitteres.getKlientKorrelasjonId().getKlientKorrelasjonId());
+                meldingSomSkalKvitteres.getKlientKorrelasjonId().toString());
         }
 
         return builder.build();

--- a/src/main/java/no/ks/fiks/io/client/SvarSender.java
+++ b/src/main/java/no/ks/fiks/io/client/SvarSender.java
@@ -86,11 +86,25 @@ public class SvarSender {
         amqpChannelFeedbackHandler.getHandleNackWithRequeue().run();
     }
 
+    private ImmutableMap<String, String> genererEgendefinerteHeadere() {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+
+        if (meldingSomSkalKvitteres.getKlientKorrelasjonId() != null &&
+            meldingSomSkalKvitteres.getKlientKorrelasjonId().getKlientKorrelasjonId() != null) {
+            builder.put(Melding.HeaderKlientKorrelasjonId,
+                meldingSomSkalKvitteres.getKlientKorrelasjonId().getKlientKorrelasjonId());
+        }
+
+        return builder.build();
+    }
+
     private MeldingSpesifikasjonApiModel.MeldingSpesifikasjonApiModelBuilder fellesBuilder(String meldingType) {
+
         return MeldingSpesifikasjonApiModel.builder()
             .avsenderKontoId(meldingSomSkalKvitteres.getMottakerKontoId().getUuid())
             .mottakerKontoId(meldingSomSkalKvitteres.getAvsenderKontoId().getUuid())
             .svarPaMelding(meldingSomSkalKvitteres.getMeldingId().getUuid())
-            .meldingType(meldingType);
+            .meldingType(meldingType)
+            .headere(genererEgendefinerteHeadere());
     }
 }

--- a/src/main/java/no/ks/fiks/io/client/model/KlientKorrelasjonId.java
+++ b/src/main/java/no/ks/fiks/io/client/model/KlientKorrelasjonId.java
@@ -7,4 +7,9 @@ import lombok.Value;
 public class KlientKorrelasjonId {
     @Nullable
     String klientKorrelasjonId;
+
+    @Override
+    public String toString() {
+        return klientKorrelasjonId;
+    }
 }

--- a/src/main/java/no/ks/fiks/io/client/model/KlientKorrelasjonId.java
+++ b/src/main/java/no/ks/fiks/io/client/model/KlientKorrelasjonId.java
@@ -1,0 +1,10 @@
+package no.ks.fiks.io.client.model;
+
+import jakarta.annotation.Nullable;
+import lombok.Value;
+
+@Value
+public class KlientKorrelasjonId {
+    @Nullable
+    String klientKorrelasjonId;
+}

--- a/src/main/java/no/ks/fiks/io/client/model/Melding.java
+++ b/src/main/java/no/ks/fiks/io/client/model/Melding.java
@@ -1,13 +1,11 @@
 package no.ks.fiks.io.client.model;
 
-import no.ks.fiks.io.klient.SendtMeldingApiModel;
-
 import java.util.Map;
-import java.util.UUID;
 
 public interface Melding {
 
     static final String HeaderKlientMeldingId = "klientMeldingId";
+    static final String HeaderKlientKorrelasjonId = "klientKorrelasjonId" ;
 
     MeldingId getMeldingId();
 
@@ -24,4 +22,6 @@ public interface Melding {
     Map<String, String> getHeadere();
 
     MeldingId getKlientMeldingId();
+
+    KlientKorrelasjonId getKlientKorrelasjonId();
 }

--- a/src/main/java/no/ks/fiks/io/client/model/MeldingRequest.java
+++ b/src/main/java/no/ks/fiks/io/client/model/MeldingRequest.java
@@ -19,6 +19,7 @@ public class MeldingRequest implements MeldingSpesifikasjon {
     @Nullable private MeldingId svarPaMelding;
     @Nullable private MeldingId klientMeldingId;
     @Nullable private Map<String, String> headere;
+    @Nullable private KlientKorrelasjonId korrelasjonsId;
 
     // Definerer denne for å hjelpe javadoc. Blir fylt ut av lombok pga Builder-annotasjon.
     public static class MeldingRequestBuilder {}
@@ -46,6 +47,17 @@ public class MeldingRequest implements MeldingSpesifikasjon {
                     copyHeadere.put(Melding.HeaderKlientMeldingId, klientMeldingId.getUuid().toString());
                 } else if(!Objects.equals(klientMeldingId.getUuid().toString(), headerKlientMeldingId)) {
                     throw new IllegalArgumentException(String.format("Property klientMeldingId er ulik %s-entry angitt via headere-property.", Melding.HeaderKlientMeldingId));
+                }
+            }
+
+            final KlientKorrelasjonId korrelasjonsId = super.korrelasjonsId;
+            if(null != korrelasjonsId) {
+                final String headerKorrelasjonsId = copyHeadere.get(Melding.HeaderKlientKorrelasjonId);
+
+                if(null == headerKorrelasjonsId) {
+                    copyHeadere.put(Melding.HeaderKlientKorrelasjonId, korrelasjonsId.getKlientKorrelasjonId());
+                } else if(!Objects.equals(korrelasjonsId.getKlientKorrelasjonId(), headerKorrelasjonsId)) {
+                    throw new IllegalArgumentException(String.format("Property korrelasjonsId er ulik %s-entry angitt via headere-property.", Melding.HeaderKlientKorrelasjonId));
                 }
             }
 

--- a/src/main/java/no/ks/fiks/io/client/model/MottattMelding.java
+++ b/src/main/java/no/ks/fiks/io/client/model/MottattMelding.java
@@ -50,6 +50,8 @@ public class MottattMelding implements Melding {
 
     private MeldingId klientMeldingId;
 
+    private KlientKorrelasjonId klientKorrelasjonId;
+
     public static MottattMelding fromMottattMeldingMetadata(
         MottattMeldingMetadata melding,
         boolean harPaylod,
@@ -66,6 +68,7 @@ public class MottattMelding implements Melding {
             .ttl(Optional.ofNullable(melding.getTtl()).map(Duration::ofMillis).orElse(null))
             .svarPaMelding(melding.getSvarPaMelding() != null ? new MeldingId(melding.getSvarPaMelding()) : null)
             .klientMeldingId(getKlientMeldingIdFromHeader(melding))
+            .klientKorrelasjonId(getKorrelasjonsIdFromHeader(melding))
             .headere(melding.getHeadere() != null ? melding.getHeadere() : Collections.emptyMap())
             .resendt(melding.isResendt())
                 .writeKryptertZip(writeKryptertZip)
@@ -112,6 +115,17 @@ public class MottattMelding implements Melding {
         if(melding.getHeadere() != null && melding.getHeadere().get(HeaderKlientMeldingId) != null) {
             try {
                 return new MeldingId(UUID.fromString(melding.getHeadere().get(HeaderKlientMeldingId)));
+            } catch (IllegalArgumentException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private static KlientKorrelasjonId getKorrelasjonsIdFromHeader(MottattMeldingMetadata melding) {
+        if(melding.getHeadere() != null && melding.getHeadere().get(HeaderKlientKorrelasjonId) != null) {
+            try {
+                return new KlientKorrelasjonId(melding.getHeadere().get(HeaderKlientKorrelasjonId));
             } catch (IllegalArgumentException e) {
                 return null;
             }

--- a/src/main/java/no/ks/fiks/io/client/model/SendtMelding.java
+++ b/src/main/java/no/ks/fiks/io/client/model/SendtMelding.java
@@ -22,6 +22,7 @@ public class SendtMelding implements Melding {
     private Map<String, String> headere;
     private MeldingId svarPaMelding;
     private MeldingId klientMeldingId;
+    private KlientKorrelasjonId klientKorrelasjonId;
 
     public static SendtMelding fromSendResponse(@NonNull SendtMeldingApiModel melding) {
         return SendtMelding.builder()
@@ -33,6 +34,7 @@ public class SendtMelding implements Melding {
             .headere(melding.getHeadere() != null ? melding.getHeadere() : Collections.emptyMap())
             .svarPaMelding(melding.getSvarPaMelding() != null ? new MeldingId(melding.getSvarPaMelding()) : null)
             .klientMeldingId(getKlientMeldingIdFromHeader(melding))
+            .klientKorrelasjonId(getKorrelasjonsIdFromHeader(melding))
             .build();
     }
 
@@ -40,6 +42,17 @@ public class SendtMelding implements Melding {
         if(melding.getHeadere() != null && melding.getHeadere().get(HeaderKlientMeldingId) != null) {
             try {
                 return new MeldingId(UUID.fromString(melding.getHeadere().get(HeaderKlientMeldingId)));
+            } catch (IllegalArgumentException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private static KlientKorrelasjonId getKorrelasjonsIdFromHeader(SendtMeldingApiModel melding) {
+        if (melding.getHeadere() != null && melding.getHeadere().get(HeaderKlientKorrelasjonId) != null) {
+            try {
+                return new KlientKorrelasjonId(melding.getHeadere().get(HeaderKlientKorrelasjonId));
             } catch (IllegalArgumentException e) {
                 return null;
             }

--- a/src/test/java/no/ks/fiks/io/client/SendtMeldingTest.java
+++ b/src/test/java/no/ks/fiks/io/client/SendtMeldingTest.java
@@ -1,6 +1,7 @@
 package no.ks.fiks.io.client;
 
 import com.google.common.collect.ImmutableMap;
+import no.ks.fiks.io.client.model.KlientKorrelasjonId;
 import no.ks.fiks.io.client.model.Melding;
 import no.ks.fiks.io.client.model.MeldingId;
 import no.ks.fiks.io.client.model.SendtMelding;
@@ -8,7 +9,6 @@ import no.ks.fiks.io.klient.SendtMeldingApiModel;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -39,8 +39,11 @@ class SendtMeldingTest {
     }
 
     @Test
-    void fromSendResponseWithKlientMeldingId() {
+    void fromSendResponseWithKlientMeldingIdAndKorrelasjonId() {
         final MeldingId klientMeldingId = new MeldingId(UUID.randomUUID());
+        final KlientKorrelasjonId klientKorrelasjonsId = new KlientKorrelasjonId((UUID.randomUUID().toString()));
+        assertNotNull(klientKorrelasjonsId.getKlientKorrelasjonId());
+
         final SendtMeldingApiModel sendtMeldingApiModel = SendtMeldingApiModel.builder()
             .meldingId(UUID.randomUUID())
             .mottakerKontoId(UUID.randomUUID())
@@ -49,7 +52,9 @@ class SendtMeldingTest {
             .svarPaMelding(UUID.randomUUID())
             .dokumentlagerId(UUID.randomUUID())
             .ttl(TimeUnit.DAYS.toMillis(5L))
-            .headere(ImmutableMap.of(Melding.HeaderKlientMeldingId, klientMeldingId.toString()))
+            .headere(ImmutableMap.of(Melding.HeaderKlientMeldingId, klientMeldingId.toString(),
+                 Melding.HeaderKlientKorrelasjonId, klientKorrelasjonsId.getKlientKorrelasjonId()
+                ))
             .build();
         final SendtMelding sendtMelding = SendtMelding.fromSendResponse(sendtMeldingApiModel);
         assertAll(
@@ -58,7 +63,8 @@ class SendtMeldingTest {
             () -> assertEquals(sendtMeldingApiModel.getAvsenderKontoId(), sendtMelding.getAvsenderKontoId().getUuid()),
             () -> assertEquals(sendtMeldingApiModel.getSvarPaMelding(), sendtMelding.getSvarPaMelding().getUuid()),
             () -> assertEquals(sendtMeldingApiModel.getTtl(), sendtMelding.getTtl().toMillis()),
-            () -> assertEquals(sendtMeldingApiModel.getHeadere().get(Melding.HeaderKlientMeldingId), sendtMelding.getKlientMeldingId().toString())
+            () -> assertEquals(sendtMeldingApiModel.getHeadere().get(Melding.HeaderKlientMeldingId), sendtMelding.getKlientMeldingId().toString()),
+            () -> assertEquals(sendtMeldingApiModel.getHeadere().get(Melding.HeaderKlientKorrelasjonId), sendtMelding.getKlientKorrelasjonId().getKlientKorrelasjonId())
         );
     }
 

--- a/src/test/java/no/ks/fiks/io/client/SendtMeldingTest.java
+++ b/src/test/java/no/ks/fiks/io/client/SendtMeldingTest.java
@@ -64,7 +64,7 @@ class SendtMeldingTest {
             () -> assertEquals(sendtMeldingApiModel.getSvarPaMelding(), sendtMelding.getSvarPaMelding().getUuid()),
             () -> assertEquals(sendtMeldingApiModel.getTtl(), sendtMelding.getTtl().toMillis()),
             () -> assertEquals(sendtMeldingApiModel.getHeadere().get(Melding.HeaderKlientMeldingId), sendtMelding.getKlientMeldingId().toString()),
-            () -> assertEquals(sendtMeldingApiModel.getHeadere().get(Melding.HeaderKlientKorrelasjonId), sendtMelding.getKlientKorrelasjonId().getKlientKorrelasjonId())
+            () -> assertEquals(sendtMeldingApiModel.getHeadere().get(Melding.HeaderKlientKorrelasjonId), sendtMelding.getKlientKorrelasjonId().toString())
         );
     }
 

--- a/src/test/java/no/ks/fiks/io/client/SvarSenderTest.java
+++ b/src/test/java/no/ks/fiks/io/client/SvarSenderTest.java
@@ -56,7 +56,7 @@ class SvarSenderTest {
 
         final byte[] buf = {0, 1, 0, 1};
         try (final InputStream inputStream = new ByteArrayInputStream(buf)) {
-            final MottattMelding mottattMelding = createMottattMelding(buf, inputStream);
+            final MottattMelding mottattMelding = createMottattMelding(buf, inputStream, false);
 
             final SvarSender svarSender = createSvarSender(buf, mottattMelding);
             when(fiksIOSender.send(isA(MeldingSpesifikasjonApiModel.class), isA(Optional.class)))
@@ -85,7 +85,7 @@ class SvarSenderTest {
 
         final byte[] buf = {0, 1, 0, 1};
         try (final InputStream inputStream = new ByteArrayInputStream(buf)) {
-            final MottattMelding mottattMelding = createMottattMelding(buf, inputStream);
+            final MottattMelding mottattMelding = createMottattMelding(buf, inputStream, false);
             final MeldingId klientMeldingId = new MeldingId(UUID.randomUUID());
             final SvarSender svarSender = createSvarSender(buf, mottattMelding);
             when(fiksIOSender.send(isA(MeldingSpesifikasjonApiModel.class), isA(Optional.class)))
@@ -110,12 +110,67 @@ class SvarSenderTest {
         }
     }
 
+    @DisplayName("Sender svar med klientKorrelasjonId")
+    @Test
+    void svarWithKlientkorrelasjonId() throws IOException {
+        final byte[] buf = {0, 1, 0, 1};
+        try (final InputStream inputStream = new ByteArrayInputStream(buf)) {
+            final MottattMelding mottattMelding = createMottattMelding(buf, inputStream,true);
+            final SvarSender svarSender = createSvarSender(buf, mottattMelding);
+
+            when(fiksIOSender.send(isA(MeldingSpesifikasjonApiModel.class), isA(Optional.class)))
+                .thenAnswer((Answer<SendtMeldingApiModel>) invocation -> {
+                    MeldingSpesifikasjonApiModel meldingSpesifikasjonApiModel = invocation.getArgument(0);
+                    return SendtMeldingApiModel.builder()
+                        .avsenderKontoId(meldingSpesifikasjonApiModel.getAvsenderKontoId())
+                        .meldingId(UUID.randomUUID())
+                        .mottakerKontoId(meldingSpesifikasjonApiModel.getMottakerKontoId())
+                        .ttl(Duration.ofHours(1L).toMillis())
+                        .meldingType(MELDING_TYPE)
+                        .headere(ImmutableMap.of(Melding.HeaderKlientKorrelasjonId, meldingSpesifikasjonApiModel.getHeadere().get(Melding.HeaderKlientKorrelasjonId)))
+                        .build();
+                });
+
+            final SendtMelding sendtMelding = svarSender.svar(mottattMelding.getMeldingType());
+
+            assertNotNull(sendtMelding);
+            assertEquals(mottattMelding.getKlientKorrelasjonId().getKlientKorrelasjonId(), sendtMelding.getKlientKorrelasjonId().getKlientKorrelasjonId());
+            verify(fiksIOSender).send(isA(MeldingSpesifikasjonApiModel.class), isA(Optional.class));
+            verifyNoMoreInteractions(fiksIOSender);
+        }
+    }
+
+    @DisplayName("Sender svar uten klientKorrelasjonId")
+    @Test
+    void svarWithoutKlientkorrelasjonId() throws IOException {
+        final byte[] buf = {0, 1, 0, 1};
+        try (final InputStream inputStream = new ByteArrayInputStream(buf)) {
+            final MottattMelding mottattMelding = createMottattMelding(buf, inputStream, false);
+            final SvarSender svarSender = createSvarSender(buf, mottattMelding);
+
+            when(fiksIOSender.send(any(), any())).thenAnswer(invocation -> {
+                MeldingSpesifikasjonApiModel spesifikasjon = invocation.getArgument(0);
+                return SendtMeldingApiModel.builder()
+                    .avsenderKontoId(spesifikasjon.getAvsenderKontoId())
+                    .meldingId(UUID.randomUUID())
+                    .mottakerKontoId(spesifikasjon.getMottakerKontoId())
+                    .ttl(Duration.ofHours(1L).toMillis())
+                    .meldingType(MELDING_TYPE)
+                    .headere(spesifikasjon.getHeadere())
+                    .build();
+            });
+
+            SendtMelding sendtMelding = svarSender.svar(mottattMelding.getMeldingType());
+            assertNull(sendtMelding.getKlientKorrelasjonId());
+        }
+    }
+
     @DisplayName("Ack")
     @Test
     void ack() throws IOException {
         final byte[] buf = {0, 1, 0, 1};
         try (final InputStream inputStream = new ByteArrayInputStream(buf)) {
-            final MottattMelding mottattMelding = createMottattMelding(buf, inputStream);
+            final MottattMelding mottattMelding = createMottattMelding(buf, inputStream, false);
             final SvarSender svarSender = createSvarSender(buf, mottattMelding);
             svarSender.ack();
             assertTrue(ackCompleted.get());
@@ -128,7 +183,7 @@ class SvarSenderTest {
     void nack() throws IOException {
         final byte[] buf = {0, 1, 0, 1};
         try (final InputStream inputStream = new ByteArrayInputStream(buf)) {
-            final MottattMelding mottattMelding = createMottattMelding(buf, inputStream);
+            final MottattMelding mottattMelding = createMottattMelding(buf, inputStream, false);
             final SvarSender svarSender = createSvarSender(buf, mottattMelding);
             svarSender.nack();
             assertTrue(nacked.get());
@@ -141,7 +196,7 @@ class SvarSenderTest {
     void nackWithRequeue() throws IOException {
         final byte[] buf = {0, 1, 0, 1};
         try (final InputStream inputStream = new ByteArrayInputStream(buf)) {
-            final MottattMelding mottattMelding = createMottattMelding(buf, inputStream);
+            final MottattMelding mottattMelding = createMottattMelding(buf, inputStream, false);
             final SvarSender svarSender = createSvarSender(buf, mottattMelding);
             svarSender.nackWithRequeue();
             assertTrue(nackedWithRequeue.get());
@@ -167,13 +222,17 @@ class SvarSenderTest {
             .build();
     }
 
-    private MottattMelding createMottattMelding(final byte[] buf, final InputStream inputStream) {
+    private MottattMelding createMottattMelding(final byte[] buf, final InputStream inputStream, boolean medKorrelasjonID) {
+
+        final KlientKorrelasjonId klientKorrelasjonId = medKorrelasjonID ? new KlientKorrelasjonId(UUID.randomUUID().toString()) : null;
+
         return MottattMelding.builder()
             .meldingId(new MeldingId(UUID.randomUUID()))
             .meldingType(MELDING_TYPE)
             .avsenderKontoId(new KontoId(UUID.randomUUID()))
             .mottakerKontoId(new KontoId(UUID.randomUUID()))
             .ttl(Duration.ofHours(1L))
+            .klientKorrelasjonId(klientKorrelasjonId)
             .headere(Collections.emptyMap())
             .writeDekryptertZip(p -> LOGGER.info("Dekryptert '{}'", p))
             .writeKryptertZip(p -> LOGGER.info("Kryptert '{}'", p))

--- a/src/test/java/no/ks/fiks/io/client/SvarSenderTest.java
+++ b/src/test/java/no/ks/fiks/io/client/SvarSenderTest.java
@@ -134,7 +134,7 @@ class SvarSenderTest {
             final SendtMelding sendtMelding = svarSender.svar(mottattMelding.getMeldingType());
 
             assertNotNull(sendtMelding);
-            assertEquals(mottattMelding.getKlientKorrelasjonId().getKlientKorrelasjonId(), sendtMelding.getKlientKorrelasjonId().getKlientKorrelasjonId());
+            assertEquals(mottattMelding.getKlientKorrelasjonId().toString(), sendtMelding.getKlientKorrelasjonId().toString());
             verify(fiksIOSender).send(isA(MeldingSpesifikasjonApiModel.class), isA(Optional.class));
             verifyNoMoreInteractions(fiksIOSender);
         }

--- a/src/test/java/no/ks/fiks/io/client/model/MottattMeldingTest.java
+++ b/src/test/java/no/ks/fiks/io/client/model/MottattMeldingTest.java
@@ -154,4 +154,35 @@ class MottattMeldingTest {
             () -> new NullInputStream(0L), () -> new ZipInputStream(new NullInputStream(100L)));
         assertEquals(klientMeldingId, mottattMelding.getKlientMeldingId());
     }
+
+    @DisplayName("Bygger mottatt melding inkludert korrelasjonsId")
+    @Test
+    void fromMottattMeldingMetadataMedKorrelasjonsId() {
+        final KlientKorrelasjonId korrelasjonsId = new KlientKorrelasjonId(UUID.randomUUID().toString());
+        final MeldingId klientKorrelasjonId = new MeldingId(UUID.randomUUID());
+        assertNotNull(korrelasjonsId.getKlientKorrelasjonId());
+
+        final MottattMeldingMetadata mottattMeldingMetadata = MottattMeldingMetadata.builder()
+            .avsenderKontoId(UUID.randomUUID())
+            .meldingId(UUID.randomUUID())
+            .meldingType("meldingType")
+            .mottakerKontoId(UUID.randomUUID())
+            .svarPaMelding(UUID.randomUUID())
+            .deliveryTag(Long.MAX_VALUE)
+            .ttl(Duration.ofMinutes(22L).toMillis())
+            .headere(ImmutableMap.of(Melding.HeaderKlientMeldingId, klientKorrelasjonId.toString(),
+                Melding.HeaderKlientKorrelasjonId, korrelasjonsId.getKlientKorrelasjonId()))
+            .build();
+
+        final MottattMelding mottattMelding = MottattMelding.fromMottattMeldingMetadata(
+            mottattMeldingMetadata,
+            true, path -> {
+            },
+            path -> {
+            },
+            () -> new NullInputStream(0L), () -> new ZipInputStream(new NullInputStream(100L)));
+
+        assertEquals(korrelasjonsId, mottattMelding.getKlientKorrelasjonId());
+        assertEquals(klientKorrelasjonId, mottattMelding.getKlientMeldingId());
+    }
 }


### PR DESCRIPTION
**Dette er gjort:**

- Lagt inn støtte for klientKorrelasjonId 

Det er nå mulig å legge til en `klientKorrelasjonId` i en egendefinert header når man sender en melding. Denne ID blir med hele løpet i mottatmelding og sendes som svar tilbake til avsender. 

Komponenttest med lokal snapshot er skrevet og kommer i en egen PR. 