### PR TITLE
Legger til støtte for å sette rpcTimeout

### DIFF
--- a/fiks-io-klient-java/src/main/java/no/ks/fiks/io/client/AmqpHandler.java
+++ b/fiks-io-klient-java/src/main/java/no/ks/fiks/io/client/AmqpHandler.java
@@ -173,6 +173,7 @@ class AmqpHandler implements Closeable {
         factory.setPort(amqpKonf.getPort());
         factory.setUsername(intKonf.getIntegrasjonId().toString());
         factory.setAutomaticRecoveryEnabled(true);
+        factory.setChannelRpcTimeout(amqpKonf.getRpcTimeout());
 
         try {
             factory.useSslProtocol(SSLContext.getDefault());

--- a/fiks-io-klient-java/src/main/java/no/ks/fiks/io/client/konfigurasjon/AmqpKonfigurasjon.java
+++ b/fiks-io-klient-java/src/main/java/no/ks/fiks/io/client/konfigurasjon/AmqpKonfigurasjon.java
@@ -47,4 +47,9 @@ public class AmqpKonfigurasjon {
      * Konfigurasjon for test.
      */
     public static final AmqpKonfigurasjon TEST = AmqpKonfigurasjon.builder().host("io.fiks.test.ks.no").build();
+
+    /**
+     * Ikke påkrevd felt. RPC timeout i millisekund. Trenger stort sett ikke endres.
+     */
+    @Builder.Default private Integer rpcTimeout = 10000;
 }


### PR DESCRIPTION
Rabbitmq klient 5.30.0 fikset en bug som gjorde at denne verdien ikke ble brukt. For å sikre samme oppførsel som før må denne verdien settes ved opprettelse av connection. 