### PR TITLE
Legg til støtte for autentisering med asymmetrisk nøkkel i Maskinporten.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ final FiksIOKonfigurasjon fiksIOKonfigurasjon = FiksIOKonfigurasjon.builder()
     .fiksIntegrasjonKonfigurasjon(FiksIntegrasjonKonfigurasjon.builder()
         .integrasjonId(integrationId)
         .integrasjonPassord(integrationPassword)
-        .idPortenKonfigurasjon(IdPortenKonfigurasjon.TEST
+        .idPortenKonfigurasjon(IdPortenKonfigurasjon.test()
             .klientId("din klientid")
             .keyIdentifier("din-key-id") // settes som JWT kid-header
             .build())

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ final FiksIOKonfigurasjon fiksIOKonfigurasjon = FiksIOKonfigurasjon.builder()
         .integrasjonPassord(integrationPassword)
         .idPortenKonfigurasjon(IdPortenKonfigurasjon.test()
             .klientId("din klientid")
-            .keyIdentifier("din-key-id") // settes som JWT kid-header
+            .keyIdentifier("din-key-id")
             .build())
         .build())
     .asymmetriskNokkelKonfigurasjon(AsymmetriskNokkelKonfigurasjon.builder()

--- a/README.md
+++ b/README.md
@@ -108,6 +108,31 @@ private static IdPortenKonfigurasjon createMaskinportenPortenKonfigurasjon() {
 }
 ```
 
+##### Autentisering med asymmetrisk nøkkel
+Som et alternativ til virksomhetssertifikat kan Maskinporten-autentiseringen settes opp med en asymmetrisk nøkkel
+(privat nøkkel + `keyIdentifier`). `keyIdentifier` settes på `IdPortenKonfigurasjon` og benyttes som JWT `kid`-header,
+mens den private nøkkelen angis via `AsymmetriskNokkelKonfigurasjon` på `FiksIOKonfigurasjon`. Merk at ASiC-E-signering
+fortsatt krever et X.509-sertifikat, så `VirksomhetssertifikatKonfigurasjon` må fortsatt oppgis for å sende/motta meldinger.
+```java
+final FiksIOKonfigurasjon fiksIOKonfigurasjon = FiksIOKonfigurasjon.builder()
+    .fiksIntegrasjonKonfigurasjon(FiksIntegrasjonKonfigurasjon.builder()
+        .integrasjonId(integrationId)
+        .integrasjonPassord(integrationPassword)
+        .idPortenKonfigurasjon(IdPortenKonfigurasjon.TEST
+            .klientId("din klientid")
+            .keyIdentifier("din-key-id") // settes som JWT kid-header
+            .build())
+        .build())
+    .asymmetriskNokkelKonfigurasjon(AsymmetriskNokkelKonfigurasjon.builder()
+        .privatNokkel(maskinportenPrivateKey)
+        .build())
+    .virksomhetssertifikatKonfigurasjon(virksomhetssertifikatKonfigurasjon) // kreves fortsatt for ASiC-E-signering
+    .kontoKonfigurasjon(kontoKonfigurasjon)
+    .build();
+```
+`defaultProdConfiguration` og `defaultTestConfiguration` har tilsvarende overloads som tar `keyIdentifier` og
+`AsymmetriskNokkelKonfigurasjon` som ekstra argumenter.
+
 
 For å gjøre det enklere å sette opp standard konfigurasjon for *test* og *prod* miljøene, finnes det i tillegg to funksjoner `defaultProdConfiguration` og `defaultTestConfiguration` for å lage default konfigurasjon. Påkrevde felter angis som argument, slik:
 ```java

--- a/fiks-io-klient-java/src/main/java/no/ks/fiks/io/client/FiksIOKlientFactory.java
+++ b/fiks-io-klient-java/src/main/java/no/ks/fiks/io/client/FiksIOKlientFactory.java
@@ -286,7 +286,7 @@ public class FiksIOKlientFactory {
             .build();
     }
 
-    private static Maskinportenklient getMaskinportenKlient(@NonNull FiksIOKonfigurasjon konfigurasjon) {
+     static Maskinportenklient getMaskinportenKlient(@NonNull FiksIOKonfigurasjon konfigurasjon) {
         MaskinportenklientProperties maskinportenklientProperties = MaskinportenklientProperties.builder()
             .audience(konfigurasjon.getFiksIntegrasjonKonfigurasjon()
                 .getIdPortenKonfigurasjon()
@@ -300,7 +300,23 @@ public class FiksIOKlientFactory {
                 .getAccessTokenUri())
             .build();
 
+        final String keyIdentifier = konfigurasjon.getFiksIntegrasjonKonfigurasjon()
+            .getIdPortenKonfigurasjon()
+            .getKeyIdentifier();
+
         try {
+            if (keyIdentifier != null) {
+                final var asymmetriskNokkelKonfigurasjon = konfigurasjon.getAsymmetriskNokkelKonfigurasjon();
+                if (asymmetriskNokkelKonfigurasjon == null) {
+                    throw new IllegalStateException("keyIdentifier er satt på IdPortenKonfigurasjon, men asymmetriskNokkelKonfigurasjon mangler på FiksIOKonfigurasjon");
+                }
+                return Maskinportenklient.builder()
+                    .withPrivateKey(asymmetriskNokkelKonfigurasjon.getPrivatNokkel())
+                    .usingAsymmetricKey(keyIdentifier)
+                    .withProperties(maskinportenklientProperties)
+                    .build();
+            }
+
             final var keyStore = konfigurasjon.getVirksomhetssertifikatKonfigurasjon().getKeyStore();
             return Maskinportenklient.builder()
                 .withPrivateKey((PrivateKey) keyStore.getKey(konfigurasjon.getVirksomhetssertifikatKonfigurasjon().getKeyAlias(), konfigurasjon.getVirksomhetssertifikatKonfigurasjon().getKeyPassword().toCharArray()))

--- a/fiks-io-klient-java/src/main/java/no/ks/fiks/io/client/FiksIOKlientFactory.java
+++ b/fiks-io-klient-java/src/main/java/no/ks/fiks/io/client/FiksIOKlientFactory.java
@@ -303,13 +303,14 @@ public class FiksIOKlientFactory {
         final String keyIdentifier = konfigurasjon.getFiksIntegrasjonKonfigurasjon()
             .getIdPortenKonfigurasjon()
             .getKeyIdentifier();
+        final var asymmetriskNokkelKonfigurasjon = konfigurasjon.getAsymmetriskNokkelKonfigurasjon();
+
+        if ((keyIdentifier == null) != (asymmetriskNokkelKonfigurasjon == null)) {
+            throw new IllegalStateException("keyIdentifier på IdPortenKonfigurasjon og asymmetriskNokkelKonfigurasjon på FiksIOKonfigurasjon må enten begge være satt (asymmetrisk nøkkel) eller begge være utelatt (virksomhetssertifikat)");
+        }
 
         try {
             if (keyIdentifier != null) {
-                final var asymmetriskNokkelKonfigurasjon = konfigurasjon.getAsymmetriskNokkelKonfigurasjon();
-                if (asymmetriskNokkelKonfigurasjon == null) {
-                    throw new IllegalStateException("keyIdentifier er satt på IdPortenKonfigurasjon, men asymmetriskNokkelKonfigurasjon mangler på FiksIOKonfigurasjon");
-                }
                 return Maskinportenklient.builder()
                     .withPrivateKey(asymmetriskNokkelKonfigurasjon.getPrivatNokkel())
                     .usingAsymmetricKey(keyIdentifier)

--- a/fiks-io-klient-java/src/main/java/no/ks/fiks/io/client/konfigurasjon/AsymmetriskNokkelKonfigurasjon.java
+++ b/fiks-io-klient-java/src/main/java/no/ks/fiks/io/client/konfigurasjon/AsymmetriskNokkelKonfigurasjon.java
@@ -1,0 +1,30 @@
+package no.ks.fiks.io.client.konfigurasjon;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+import java.security.PrivateKey;
+
+/**
+ * Konfigurasjon for asymmetrisk nøkkel som benyttes til Maskinporten-autentisering, som et alternativ
+ * til {@link VirksomhetssertifikatKonfigurasjon}. Brukes sammen med {@code keyIdentifier} på
+ * {@link IdPortenKonfigurasjon}, som settes som JWT {@code kid}-header.
+ * <p>
+ * Merk at ASiC-E-signering fortsatt krever et eget X.509-sertifikat
+ * (se {@link VirksomhetssertifikatKonfigurasjon}).
+ */
+@Value
+@Builder
+public class AsymmetriskNokkelKonfigurasjon {
+
+    /**
+     * Påkrevd. Privat nøkkel som er registrert i Maskinporten for asymmetrisk nøkkel-autentisering.
+     */
+    @NonNull PrivateKey privatNokkel;
+
+    @Override
+    public String toString() {
+        return "AsymmetriskNokkelKonfigurasjon{privatNokkel=*****}";
+    }
+}

--- a/fiks-io-klient-java/src/main/java/no/ks/fiks/io/client/konfigurasjon/FiksIOKonfigurasjon.java
+++ b/fiks-io-klient-java/src/main/java/no/ks/fiks/io/client/konfigurasjon/FiksIOKonfigurasjon.java
@@ -37,6 +37,13 @@ public class FiksIOKonfigurasjon {
     @NonNull private FiksIntegrasjonKonfigurasjon fiksIntegrasjonKonfigurasjon;
 
     /**
+     * Ikke påkrevd. Asymmetrisk nøkkel som benyttes til Maskinporten-autentisering, som et alternativ
+     * til {@link VirksomhetssertifikatKonfigurasjon}. Brukes sammen med {@code keyIdentifier} på
+     * {@link IdPortenKonfigurasjon}. Se {@link AsymmetriskNokkelKonfigurasjon}.
+     */
+    private AsymmetriskNokkelKonfigurasjon asymmetriskNokkelKonfigurasjon;
+
+    /**
      * Ikke påkrevd. Kan brukes for å overkjøre defaults for fiks-api-host. Se {@link FiksApiKonfigurasjon}
      */
     @Builder.Default private FiksApiKonfigurasjon fiksApiKonfigurasjon = FiksApiKonfigurasjon.builder().build();
@@ -107,6 +114,68 @@ public class FiksIOKonfigurasjon {
                 .build())
             .kontoKonfigurasjon(kontoKonfigurasjon)
             .virksomhetssertifikatKonfigurasjon(virksomhetssertifikatKonfigurasjon)
+            .build();
+    }
+
+    /**
+     * Oppretter prod-konfigurasjon som autentiserer mot Maskinporten med asymmetrisk nøkkel
+     * (privat nøkkel + {@code keyIdentifier}) i stedet for virksomhetssertifikat.
+     * {@code virksomhetssertifikatKonfigurasjon} kreves fortsatt for ASiC-E-signering.
+     */
+    public static FiksIOKonfigurasjon defaultProdConfiguration(
+        final String klientId,
+        final UUID integrasjonId,
+        final String integrasjonPassord,
+        final KontoKonfigurasjon kontoKonfigurasjon,
+        final VirksomhetssertifikatKonfigurasjon virksomhetssertifikatKonfigurasjon,
+        final String keyIdentifier,
+        final AsymmetriskNokkelKonfigurasjon asymmetriskNokkelKonfigurasjon) {
+
+        return FiksIOKonfigurasjon.builder()
+            .fiksApiKonfigurasjon(FiksApiKonfigurasjon.PROD)
+            .amqpKonfigurasjon(AmqpKonfigurasjon.PROD)
+            .fiksIntegrasjonKonfigurasjon(FiksIntegrasjonKonfigurasjon.builder()
+                .idPortenKonfigurasjon(IdPortenKonfigurasjon.PROD
+                    .klientId(klientId)
+                    .keyIdentifier(keyIdentifier)
+                    .build())
+                .integrasjonId(integrasjonId)
+                .integrasjonPassord(integrasjonPassord)
+                .build())
+            .kontoKonfigurasjon(kontoKonfigurasjon)
+            .virksomhetssertifikatKonfigurasjon(virksomhetssertifikatKonfigurasjon)
+            .asymmetriskNokkelKonfigurasjon(asymmetriskNokkelKonfigurasjon)
+            .build();
+    }
+
+    /**
+     * Oppretter test-konfigurasjon som autentiserer mot Maskinporten med asymmetrisk nøkkel
+     * (privat nøkkel + {@code keyIdentifier}) i stedet for virksomhetssertifikat.
+     * {@code virksomhetssertifikatKonfigurasjon} kreves fortsatt for ASiC-E-signering.
+     */
+    public static FiksIOKonfigurasjon defaultTestConfiguration(
+        final String klientId,
+        final UUID integrasjonId,
+        final String integrasjonPassord,
+        final KontoKonfigurasjon kontoKonfigurasjon,
+        final VirksomhetssertifikatKonfigurasjon virksomhetssertifikatKonfigurasjon,
+        final String keyIdentifier,
+        final AsymmetriskNokkelKonfigurasjon asymmetriskNokkelKonfigurasjon) {
+
+        return FiksIOKonfigurasjon.builder()
+            .fiksApiKonfigurasjon(FiksApiKonfigurasjon.TEST)
+            .amqpKonfigurasjon(AmqpKonfigurasjon.TEST)
+            .fiksIntegrasjonKonfigurasjon(FiksIntegrasjonKonfigurasjon.builder()
+                .idPortenKonfigurasjon(IdPortenKonfigurasjon.TEST
+                    .klientId(klientId)
+                    .keyIdentifier(keyIdentifier)
+                    .build())
+                .integrasjonId(integrasjonId)
+                .integrasjonPassord(integrasjonPassord)
+                .build())
+            .kontoKonfigurasjon(kontoKonfigurasjon)
+            .virksomhetssertifikatKonfigurasjon(virksomhetssertifikatKonfigurasjon)
+            .asymmetriskNokkelKonfigurasjon(asymmetriskNokkelKonfigurasjon)
             .build();
     }
 

--- a/fiks-io-klient-java/src/main/java/no/ks/fiks/io/client/konfigurasjon/FiksIOKonfigurasjon.java
+++ b/fiks-io-klient-java/src/main/java/no/ks/fiks/io/client/konfigurasjon/FiksIOKonfigurasjon.java
@@ -84,7 +84,7 @@ public class FiksIOKonfigurasjon {
             .fiksApiKonfigurasjon(FiksApiKonfigurasjon.PROD)
             .amqpKonfigurasjon(AmqpKonfigurasjon.PROD)
             .fiksIntegrasjonKonfigurasjon(FiksIntegrasjonKonfigurasjon.builder()
-                .idPortenKonfigurasjon(IdPortenKonfigurasjon.PROD
+                .idPortenKonfigurasjon(IdPortenKonfigurasjon.prod()
                     .klientId(klientId)
                     .build())
                 .integrasjonId(integrasjonId)
@@ -106,7 +106,7 @@ public class FiksIOKonfigurasjon {
             .fiksApiKonfigurasjon(FiksApiKonfigurasjon.TEST)
             .amqpKonfigurasjon(AmqpKonfigurasjon.TEST)
             .fiksIntegrasjonKonfigurasjon(FiksIntegrasjonKonfigurasjon.builder()
-                .idPortenKonfigurasjon(IdPortenKonfigurasjon.TEST
+                .idPortenKonfigurasjon(IdPortenKonfigurasjon.test()
                     .klientId(klientId)
                     .build())
                 .integrasjonId(integrasjonId)
@@ -135,7 +135,7 @@ public class FiksIOKonfigurasjon {
             .fiksApiKonfigurasjon(FiksApiKonfigurasjon.PROD)
             .amqpKonfigurasjon(AmqpKonfigurasjon.PROD)
             .fiksIntegrasjonKonfigurasjon(FiksIntegrasjonKonfigurasjon.builder()
-                .idPortenKonfigurasjon(IdPortenKonfigurasjon.PROD
+                .idPortenKonfigurasjon(IdPortenKonfigurasjon.prod()
                     .klientId(klientId)
                     .keyIdentifier(keyIdentifier)
                     .build())
@@ -166,7 +166,7 @@ public class FiksIOKonfigurasjon {
             .fiksApiKonfigurasjon(FiksApiKonfigurasjon.TEST)
             .amqpKonfigurasjon(AmqpKonfigurasjon.TEST)
             .fiksIntegrasjonKonfigurasjon(FiksIntegrasjonKonfigurasjon.builder()
-                .idPortenKonfigurasjon(IdPortenKonfigurasjon.TEST
+                .idPortenKonfigurasjon(IdPortenKonfigurasjon.test()
                     .klientId(klientId)
                     .keyIdentifier(keyIdentifier)
                     .build())

--- a/fiks-io-klient-java/src/main/java/no/ks/fiks/io/client/konfigurasjon/IdPortenKonfigurasjon.java
+++ b/fiks-io-klient-java/src/main/java/no/ks/fiks/io/client/konfigurasjon/IdPortenKonfigurasjon.java
@@ -42,8 +42,31 @@ public class IdPortenKonfigurasjon {
     ;
 
     /**
-     * Builder med ferdig prod config. Trenger klientId.
+     * Ny builder med ferdig prod config. Trenger klientId. Returnerer en frisk builder for hvert kall.
      */
+    public static IdPortenKonfigurasjonBuilder prod() {
+        return IdPortenKonfigurasjon.builder()
+            .accessTokenUri("https://maskinporten.no/token")
+            .idPortenAudience("https://maskinporten.no/");
+    }
+
+    /**
+     * Ny builder med ferdig TEST config. Kan brukes mot Fiks IO sitt testmiljø. Trenger klientId.
+     * Returnerer en frisk builder for hvert kall.
+     */
+    public static IdPortenKonfigurasjonBuilder test() {
+        return IdPortenKonfigurasjon.builder()
+            .accessTokenUri("https://test.maskinporten.no/token")
+            .idPortenAudience("https://test.maskinporten.no/");
+    }
+
+    /**
+     * Builder med ferdig prod config. Trenger klientId.
+     *
+     * @deprecated Dette er en delt, muterbar builder-instans. Verdier satt på den (f.eks. {@code keyIdentifier})
+     * lekker mellom kall i samme JVM. Bruk {@link #prod()} som returnerer en frisk builder for hvert kall.
+     */
+    @Deprecated
     public static final IdPortenKonfigurasjonBuilder PROD = IdPortenKonfigurasjon.builder()
         .accessTokenUri("https://maskinporten.no/token")
         .idPortenAudience("https://maskinporten.no/");
@@ -51,7 +74,7 @@ public class IdPortenKonfigurasjon {
     /**
      * Builder med ferdig ver2 config. Trenger klientId. Brukes mot Fiks IO i test.
      *
-     * @deprecated Bruk {@link #TEST} i stedet. Digdir holder på å fase ut VER2
+     * @deprecated Bruk {@link #test()} i stedet. Digdir holder på å fase ut VER2
      */
     @Deprecated(since = "3.3.0", forRemoval = true)
     public static final IdPortenKonfigurasjonBuilder VER2 = IdPortenKonfigurasjon.builder()
@@ -60,7 +83,11 @@ public class IdPortenKonfigurasjon {
 
     /**
      * Builder med ferdig TEST config. Kan brukes mot Fiks IO sitt testmiljø. Trenger klientId.
+     *
+     * @deprecated Dette er en delt, muterbar builder-instans. Verdier satt på den (f.eks. {@code keyIdentifier})
+     * lekker mellom kall i samme JVM. Bruk {@link #test()} som returnerer en frisk builder for hvert kall.
      */
+    @Deprecated
     public static final IdPortenKonfigurasjonBuilder TEST = IdPortenKonfigurasjon.builder()
         .accessTokenUri("https://test.maskinporten.no/token")
         .idPortenAudience("https://test.maskinporten.no/");

--- a/fiks-io-klient-java/src/main/java/no/ks/fiks/io/client/konfigurasjon/IdPortenKonfigurasjon.java
+++ b/fiks-io-klient-java/src/main/java/no/ks/fiks/io/client/konfigurasjon/IdPortenKonfigurasjon.java
@@ -29,6 +29,13 @@ public class IdPortenKonfigurasjon {
     @NonNull
     private String klientId;
 
+    /**
+     * Valgfritt. Settes som JWT {@code kid}-header ved bruk av asymmetrisk nøkkel for
+     * Maskinporten-autentisering. Når denne er satt benyttes asymmetrisk nøkkel
+     * (se {@link AsymmetriskNokkelKonfigurasjon}) i stedet for virksomhetssertifikat for autentisering.
+     */
+    private String keyIdentifier;
+
     public static class IdPortenKonfigurasjonBuilder {
     }
 

--- a/fiks-io-klient-java/src/test/java/no/ks/fiks/io/client/FiksIOKlientFactoryTest.java
+++ b/fiks-io-klient-java/src/test/java/no/ks/fiks/io/client/FiksIOKlientFactoryTest.java
@@ -140,4 +140,23 @@ class FiksIOKlientFactoryTest {
         assertThrows(RuntimeException.class, () -> FiksIOKlientFactory.getMaskinportenKlient(fiksIOKonfigurasjon));
     }
 
+    @Test
+    void getMaskinportenKlientFeilerNarAsymmetriskNokkelKonfigurasjonErSattUtenKeyIdentifier() {
+        final IdPortenKonfigurasjon idPortenKonfigurasjon = IdPortenKonfigurasjon.builder()
+            .accessTokenUri("http://localhost")
+            .idPortenAudience("audience")
+            .klientId(UUID.randomUUID().toString())
+            .build();
+        final FiksIOKonfigurasjon fiksIOKonfigurasjon = FiksIOKonfigurasjon.builder()
+            .kontoKonfigurasjon(kontoKonfigurasjon())
+            .virksomhetssertifikatKonfigurasjon(virksomhetssertifikatKonfigurasjon())
+            .fiksIntegrasjonKonfigurasjon(fiksIntegrasjonKonfigurasjon(idPortenKonfigurasjon))
+            .asymmetriskNokkelKonfigurasjon(AsymmetriskNokkelKonfigurasjon.builder()
+                .privatNokkel(TestUtil.generatePrivateKey())
+                .build())
+            .build();
+
+        assertThrows(RuntimeException.class, () -> FiksIOKlientFactory.getMaskinportenKlient(fiksIOKonfigurasjon));
+    }
+
 }

--- a/fiks-io-klient-java/src/test/java/no/ks/fiks/io/client/FiksIOKlientFactoryTest.java
+++ b/fiks-io-klient-java/src/test/java/no/ks/fiks/io/client/FiksIOKlientFactoryTest.java
@@ -1,5 +1,6 @@
 package no.ks.fiks.io.client;
 
+import no.ks.fiks.io.client.konfigurasjon.AsymmetriskNokkelKonfigurasjon;
 import no.ks.fiks.io.client.konfigurasjon.FiksApiKonfigurasjon;
 import no.ks.fiks.io.client.konfigurasjon.FiksIOKonfigurasjon;
 import no.ks.fiks.io.client.konfigurasjon.FiksIntegrasjonKonfigurasjon;
@@ -7,52 +8,114 @@ import no.ks.fiks.io.client.konfigurasjon.IdPortenKonfigurasjon;
 import no.ks.fiks.io.client.konfigurasjon.KontoKonfigurasjon;
 import no.ks.fiks.io.client.konfigurasjon.VirksomhetssertifikatKonfigurasjon;
 import no.ks.fiks.io.client.model.KontoId;
+import no.ks.fiks.maskinporten.Maskinportenklient;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class FiksIOKlientFactoryTest {
 
-    @Test
-    void build() {
-        final KontoKonfigurasjon kontoKonfigurasjon = KontoKonfigurasjon.builder()
+    private static KontoKonfigurasjon kontoKonfigurasjon() {
+        return KontoKonfigurasjon.builder()
             .kontoId(new KontoId(UUID.randomUUID()))
             .privateNokler(Arrays.asList(TestUtil.generatePrivateKey()))
             .build();
-        final VirksomhetssertifikatKonfigurasjon virksomhetssertifikatKonfigurasjon = VirksomhetssertifikatKonfigurasjon.builder()
+    }
+
+    private static VirksomhetssertifikatKonfigurasjon virksomhetssertifikatKonfigurasjon() {
+        return VirksomhetssertifikatKonfigurasjon.builder()
             .keyStorePassword("PASSWORD")
-            .keyStore(
-                TestUtil.readAliceVirksomhetssertifikat())
+            .keyStore(TestUtil.readAliceVirksomhetssertifikat())
             .keyAlias("et alias")
             .keyPassword("PASSWORD")
             .build();
+    }
+
+    private static FiksIntegrasjonKonfigurasjon fiksIntegrasjonKonfigurasjon(IdPortenKonfigurasjon idPortenKonfigurasjon) {
+        return FiksIntegrasjonKonfigurasjon.builder()
+            .integrasjonId(UUID.randomUUID())
+            .integrasjonPassord(UUID.randomUUID().toString())
+            .idPortenKonfigurasjon(idPortenKonfigurasjon)
+            .build();
+    }
+
+    @Test
+    void build() {
         final IdPortenKonfigurasjon idPortenKonfigurasjon = IdPortenKonfigurasjon.builder()
             .accessTokenUri("http://localhost")
             .idPortenAudience("audience")
-            .klientId(UUID.randomUUID()
-                .toString())
-            .build();
-        final FiksIntegrasjonKonfigurasjon fiksIntegrasjonKonfigurasjon = FiksIntegrasjonKonfigurasjon.builder()
-            .integrasjonId(UUID.randomUUID())
-            .integrasjonPassord(UUID.randomUUID()
-                .toString())
-            .idPortenKonfigurasjon(idPortenKonfigurasjon)
+            .klientId(UUID.randomUUID().toString())
             .build();
         final FiksApiKonfigurasjon fiksApiKonfigurasjon = FiksApiKonfigurasjon.builder()
             .host("localhost")
             .port(9190)
             .build();
         final FiksIOKonfigurasjon fiksIOKonfigurasjon = FiksIOKonfigurasjon.builder()
-            .kontoKonfigurasjon(kontoKonfigurasjon)
-            .virksomhetssertifikatKonfigurasjon(
-                virksomhetssertifikatKonfigurasjon)
-            .fiksIntegrasjonKonfigurasjon(fiksIntegrasjonKonfigurasjon)
+            .kontoKonfigurasjon(kontoKonfigurasjon())
+            .virksomhetssertifikatKonfigurasjon(virksomhetssertifikatKonfigurasjon())
+            .fiksIntegrasjonKonfigurasjon(fiksIntegrasjonKonfigurasjon(idPortenKonfigurasjon))
             .fiksApiKonfigurasjon(fiksApiKonfigurasjon)
             .build();
         assertThrows(RuntimeException.class, () -> new FiksIOKlientFactory(fiksIOKonfigurasjon).build());
+    }
+
+    @Test
+    void getMaskinportenKlientBrukerVirksomhetssertifikatNarKeyIdentifierIkkeErSatt() {
+        final IdPortenKonfigurasjon idPortenKonfigurasjon = IdPortenKonfigurasjon.builder()
+            .accessTokenUri("http://localhost")
+            .idPortenAudience("audience")
+            .klientId(UUID.randomUUID().toString())
+            .build();
+        final FiksIOKonfigurasjon fiksIOKonfigurasjon = FiksIOKonfigurasjon.builder()
+            .kontoKonfigurasjon(kontoKonfigurasjon())
+            .virksomhetssertifikatKonfigurasjon(virksomhetssertifikatKonfigurasjon())
+            .fiksIntegrasjonKonfigurasjon(fiksIntegrasjonKonfigurasjon(idPortenKonfigurasjon))
+            .build();
+
+        final Maskinportenklient maskinportenklient = FiksIOKlientFactory.getMaskinportenKlient(fiksIOKonfigurasjon);
+        assertNotNull(maskinportenklient);
+    }
+
+    @Test
+    void getMaskinportenKlientBrukerAsymmetriskNokkelNarKeyIdentifierErSatt() {
+        final IdPortenKonfigurasjon idPortenKonfigurasjon = IdPortenKonfigurasjon.builder()
+            .accessTokenUri("http://localhost")
+            .idPortenAudience("audience")
+            .klientId(UUID.randomUUID().toString())
+            .keyIdentifier("min-key-id")
+            .build();
+        final FiksIOKonfigurasjon fiksIOKonfigurasjon = FiksIOKonfigurasjon.builder()
+            .kontoKonfigurasjon(kontoKonfigurasjon())
+            .virksomhetssertifikatKonfigurasjon(virksomhetssertifikatKonfigurasjon())
+            .fiksIntegrasjonKonfigurasjon(fiksIntegrasjonKonfigurasjon(idPortenKonfigurasjon))
+            .asymmetriskNokkelKonfigurasjon(AsymmetriskNokkelKonfigurasjon.builder()
+                .privatNokkel(TestUtil.generatePrivateKey())
+                .build())
+            .build();
+
+        final Maskinportenklient maskinportenklient = FiksIOKlientFactory.getMaskinportenKlient(fiksIOKonfigurasjon);
+        assertNotNull(maskinportenklient);
+    }
+
+    @Test
+    void getMaskinportenKlientFeilerNarKeyIdentifierErSattUtenAsymmetriskNokkelKonfigurasjon() {
+        final IdPortenKonfigurasjon idPortenKonfigurasjon = IdPortenKonfigurasjon.builder()
+            .accessTokenUri("http://localhost")
+            .idPortenAudience("audience")
+            .klientId(UUID.randomUUID().toString())
+            .keyIdentifier("min-key-id")
+            .build();
+        final FiksIOKonfigurasjon fiksIOKonfigurasjon = FiksIOKonfigurasjon.builder()
+            .kontoKonfigurasjon(kontoKonfigurasjon())
+            .virksomhetssertifikatKonfigurasjon(virksomhetssertifikatKonfigurasjon())
+            .fiksIntegrasjonKonfigurasjon(fiksIntegrasjonKonfigurasjon(idPortenKonfigurasjon))
+            .build();
+
+        assertThrows(RuntimeException.class, () -> FiksIOKlientFactory.getMaskinportenKlient(fiksIOKonfigurasjon));
     }
 
 }

--- a/fiks-io-klient-java/src/test/java/no/ks/fiks/io/client/FiksIOKlientFactoryTest.java
+++ b/fiks-io-klient-java/src/test/java/no/ks/fiks/io/client/FiksIOKlientFactoryTest.java
@@ -9,12 +9,16 @@ import no.ks.fiks.io.client.konfigurasjon.KontoKonfigurasjon;
 import no.ks.fiks.io.client.konfigurasjon.VirksomhetssertifikatKonfigurasjon;
 import no.ks.fiks.io.client.model.KontoId;
 import no.ks.fiks.maskinporten.Maskinportenklient;
+import com.nimbusds.jose.JWSHeader;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class FiksIOKlientFactoryTest {
@@ -41,6 +45,16 @@ class FiksIOKlientFactoryTest {
             .integrasjonPassord(UUID.randomUUID().toString())
             .idPortenKonfigurasjon(idPortenKonfigurasjon)
             .build();
+    }
+
+    private static JWSHeader jwsHeader(Maskinportenklient maskinportenklient) {
+        try {
+            final Field field = Maskinportenklient.class.getDeclaredField("jwsHeader");
+            field.setAccessible(true);
+            return (JWSHeader) field.get(maskinportenklient);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Test
@@ -78,6 +92,10 @@ class FiksIOKlientFactoryTest {
 
         final Maskinportenklient maskinportenklient = FiksIOKlientFactory.getMaskinportenKlient(fiksIOKonfigurasjon);
         assertNotNull(maskinportenklient);
+
+        final JWSHeader jwsHeader = jwsHeader(maskinportenklient);
+        assertNotNull(jwsHeader.getX509CertChain());
+        assertNull(jwsHeader.getKeyID());
     }
 
     @Test
@@ -99,6 +117,10 @@ class FiksIOKlientFactoryTest {
 
         final Maskinportenklient maskinportenklient = FiksIOKlientFactory.getMaskinportenKlient(fiksIOKonfigurasjon);
         assertNotNull(maskinportenklient);
+
+        final JWSHeader jwsHeader = jwsHeader(maskinportenklient);
+        assertEquals("min-key-id", jwsHeader.getKeyID());
+        assertNull(jwsHeader.getX509CertChain());
     }
 
     @Test

--- a/fiks-io-klient-java/src/test/java/no/ks/fiks/io/client/konfigurasjon/FiksIOKonfigurasjonTest.java
+++ b/fiks-io-klient-java/src/test/java/no/ks/fiks/io/client/konfigurasjon/FiksIOKonfigurasjonTest.java
@@ -10,6 +10,8 @@ import java.util.Arrays;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class FiksIOKonfigurasjonTest {
 
@@ -100,6 +102,44 @@ class FiksIOKonfigurasjonTest {
         assertEquals(443, fiksIOKonfigurasjon.getFiksApiKonfigurasjon().getPort());
         assertEquals("io.fiks.test.ks.no", fiksIOKonfigurasjon.getAmqpKonfigurasjon().getHost());
         assertEquals(5671, fiksIOKonfigurasjon.getAmqpKonfigurasjon().getPort());
+    }
+
+    @Test
+    void keyIdentifierLekkerIkkeMellomKall() {
+        final KontoKonfigurasjon kontoKonfigurasjon = KontoKonfigurasjon.builder()
+            .kontoId(new KontoId(UUID.randomUUID()))
+            .privatNokkel(TestUtil.generatePrivateKey())
+            .build();
+        final VirksomhetssertifikatKonfigurasjon virksomhetssertifikatKonfigurasjon = VirksomhetssertifikatKonfigurasjon.builder()
+            .keyAlias("et alias")
+            .keyPassword("PASSWORD")
+            .keyStore(TestUtil.readAliceVirksomhetssertifikat())
+            .keyStorePassword("PASSWORD")
+            .build();
+
+        // Asymmetrisk konfig setter keyIdentifier
+        final FiksIOKonfigurasjon asymmetrisk = FiksIOKonfigurasjon.defaultTestConfiguration(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID(),
+            UUID.randomUUID().toString(),
+            kontoKonfigurasjon,
+            virksomhetssertifikatKonfigurasjon,
+            "min-key-id",
+            AsymmetriskNokkelKonfigurasjon.builder()
+                .privatNokkel(TestUtil.generatePrivateKey())
+                .build());
+        assertEquals("min-key-id", asymmetrisk.getFiksIntegrasjonKonfigurasjon().getIdPortenKonfigurasjon().getKeyIdentifier());
+        assertNotNull(asymmetrisk.getAsymmetriskNokkelKonfigurasjon());
+
+        // Påfølgende ordinær konfig skal IKKE arve keyIdentifier fra forrige kall
+        final FiksIOKonfigurasjon ordinaer = FiksIOKonfigurasjon.defaultTestConfiguration(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID(),
+            UUID.randomUUID().toString(),
+            kontoKonfigurasjon,
+            virksomhetssertifikatKonfigurasjon);
+        assertNull(ordinaer.getFiksIntegrasjonKonfigurasjon().getIdPortenKonfigurasjon().getKeyIdentifier());
+        assertNull(ordinaer.getAsymmetriskNokkelKonfigurasjon());
     }
 
 

--- a/fiks-io-klient-java/src/test/java/no/ks/fiks/io/client/konfigurasjon/FiksIOKonfigurasjonTest.java
+++ b/fiks-io-klient-java/src/test/java/no/ks/fiks/io/client/konfigurasjon/FiksIOKonfigurasjonTest.java
@@ -117,7 +117,6 @@ class FiksIOKonfigurasjonTest {
             .keyStorePassword("PASSWORD")
             .build();
 
-        // Asymmetrisk konfig setter keyIdentifier
         final FiksIOKonfigurasjon asymmetrisk = FiksIOKonfigurasjon.defaultTestConfiguration(
             UUID.randomUUID().toString(),
             UUID.randomUUID(),
@@ -131,7 +130,6 @@ class FiksIOKonfigurasjonTest {
         assertEquals("min-key-id", asymmetrisk.getFiksIntegrasjonKonfigurasjon().getIdPortenKonfigurasjon().getKeyIdentifier());
         assertNotNull(asymmetrisk.getAsymmetriskNokkelKonfigurasjon());
 
-        // Påfølgende ordinær konfig skal IKKE arve keyIdentifier fra forrige kall
         final FiksIOKonfigurasjon ordinaer = FiksIOKonfigurasjon.defaultTestConfiguration(
             UUID.randomUUID().toString(),
             UUID.randomUUID(),


### PR DESCRIPTION
### Bakgrunn
  fiks-io-klient-java støttet til nå kun Maskinporten-autentisering via virksomhetssertifikat
  (X.509 keystore). Denne PR-en legger til asymmetrisk nøkkel (privat nøkkel + `keyIdentifier`)
  som et alternativ, på linje med .NET-klienten (PR #299).

  Tidligere måtte Java-brukere bygge `Maskinportenklient` selv og injisere via
  `setMaskinportenAccessTokenSupplier(...)`. Nå støttes det direkte i konfigurasjonen.

  ### Endringer
  - **`IdPortenKonfigurasjon`** – nytt valgfritt `keyIdentifier`-felt. Settes som JWT `kid`-header.
  - **`AsymmetriskNokkelKonfigurasjon`** (ny) – holder den private nøkkelen (`privatNokkel`)
    registrert i Maskinporten. `toString()` er maskert.
  - **`FiksIOKonfigurasjon`** – nytt valgfritt `asymmetriskNokkelKonfigurasjon`-felt, samt nye
    overloads av `defaultProdConfiguration`/`defaultTestConfiguration` som tar `keyIdentifier` +
    `AsymmetriskNokkelKonfigurasjon`.
  - **`FiksIOKlientFactory.getMaskinportenKlient(...)`** – velger auth-metode basert på konfigurasjon:
    - `keyIdentifier` satt → `.withPrivateKey(privatNokkel).usingAsymmetricKey(keyIdentifier)` (`kid`-header)
    - ellers → eksisterende `.usingVirksomhetssertifikat(...)` (`x5c`-header)
    - tydelig feil hvis `keyIdentifier` er satt uten `asymmetriskNokkelKonfigurasjon`.
  - **README** – nytt eksempel for asymmetrisk nøkkel-oppsett.
  - **Tester** – dekker begge auth-stier, `keyIdentifier`-overload og valideringsfeil.

  ### Verifisert mot Digdir-protokollen
  JWT-grantens header skal inneholde enten `kid` eller `x5c` ([maskinporten_protocol_jwtgrant](https://docs.digdir.no/docs/Maskinporten/maskinporten_protocol_jwtgrant.html)). `kid` refererer til en forhåndsregistrert nøkkel og signeres RS256 med den private nøkkelen – ingen sertifikatkjede sendes. Dette matcher `AsymmetricKeyJWSHeaderProvider` i `maskinporten-client` 3.6.1.

  ### Bakoverkompatibilitet
  Fullt bakoverkompatibelt:
  - Nye felt er valgfrie (default `null`); `virksomhetssertifikatKonfigurasjon` er fortsatt påkrevd.
  - Eksisterende factory-metoder er urørt (asymmetrisk-varianten er nye overloads).
  - Når `keyIdentifier == null` kjøres nøyaktig samme kodesti som før.

  ### Merk: ASiC-E-signering
  Asymmetrisk nøkkel er et alternativ for *Maskinporten-autentisering*. `VirksomhetssertifikatKonfigurasjon` kreves fortsatt for ASiC-E-signering (kryptering/dekryptering ved sending og mottak), siden `AsicHandler` trenger en keystore.  En egen ASiC-konfig (slik .NET har) ville latt en ren asymmetrisk-bruker droppe keystore helt – det er bevisst utenfor scope her og denne diskjunen må tas innad i teamet.