### PR TITLE
Begrense antall opplastinger av public key

### DIFF
--- a/fiks-io-eksempel-klient/README.md
+++ b/fiks-io-eksempel-klient/README.md
@@ -154,6 +154,42 @@ curl -X 'GET' \
 - `<integrasjonpassord>`: Dit integrasjons-passord
 
 
+## Automatisk opplasting av Public Certificate
+
+Applikasjonen støtter automatisk opplasting av public certificate til Fiks IO katalog. Dette sikrer at mottakere alltid har den korrekte offentlignøkkelen for dekryptering av meldinger.
+
+### Konfigurering
+
+Referer til public key i `config.properties`:
+
+```properties
+publickey.file=/path/to/public.pem
+```
+
+### Hva skjer ved oppstart
+
+1. Hvis public key er konfigurert, valideres den mot private key
+2. Dersom public key er forskjellig fra den som er registrert i katalogen, lastes den opp
+3. Rate limiting sikrer at opplasting ikke skjer oftere enn hver 24. time
+
+### Rate Limiting
+
+For å unngå hyppige uploads implementerer applikasjonen 24-timers rate limiting:
+
+- **Første oppstart**: Public key lastes opp
+- **Restart innen 24 timer**: Opplasting hoppes over
+- **Restart etter 24 timer**: Public key lastes opp igjen (hvis endret)
+
+Cache lagres lokalt i `$TMPDIR/fiks-io/public-key-upload-cache.txt` eller i directory spesifisert via `FIKS_IO_CACHE_DIR` environment variable.
+
+Hvis man av en eller annen grunn ønsker å tvinge opplasting av public key, kan man  slette cache-filen eller redigere den for å sette en tidligere timestamp.
+
+Logging under oppstart viser status for public key opplasting:
+```
+[main] INFO PersistentPublicKeyUploadCache - Registrerte opplasting av public key for konto <uuid>
+[main] INFO PersistentPublicKeyUploadCache - Hopper over opplasting... prøv igjen etter <tidspunkt>
+```
+
 ## Ressurser
 
 - [Fiks IO dokumentasjon](https://ks-no.github.io/fiks-plattform/tjenester/fiksprotokoll/fiksio/)

--- a/fiks-io-klient-java/src/main/java/no/ks/fiks/io/client/FiksIOKlientFactory.java
+++ b/fiks-io-klient-java/src/main/java/no/ks/fiks/io/client/FiksIOKlientFactory.java
@@ -55,11 +55,18 @@ public class FiksIOKlientFactory {
     private Supplier<String> maskinportenAccessTokenSupplier;
 
     private final CloseableHttpClient httpClient;
+    private final PublicKeyUploadRateLimiter uploadCache;
 
     public FiksIOKlientFactory(@NonNull FiksIOKonfigurasjon fiksIOKonfigurasjon, PublicKeyProvider publicKeyProvider, @NonNull CloseableHttpClient httpClient) {
+        // ikke last opp nytt public cert mer enn 1 gang pr 24 timer
+        this(fiksIOKonfigurasjon, publicKeyProvider, httpClient, new PersistentPublicKeyUploadCache(24));
+    }
+
+    public FiksIOKlientFactory(@NonNull FiksIOKonfigurasjon fiksIOKonfigurasjon, PublicKeyProvider publicKeyProvider, @NonNull CloseableHttpClient httpClient, PublicKeyUploadRateLimiter uploadCache) {
         this.fiksIOKonfigurasjon = fiksIOKonfigurasjon;
         this.publicKeyProvider = publicKeyProvider;
         this.httpClient = httpClient;
+        this.uploadCache = uploadCache;
     }
 
     public FiksIOKlientFactory(@NonNull FiksIOKonfigurasjon fiksIOKonfigurasjon, PublicKeyProvider publicKeyProvider) {
@@ -117,7 +124,7 @@ public class FiksIOKlientFactory {
 
             final KeyValidatorHandler keyValidatorHandler = new KeyValidatorHandler(katalogHandler, fiksIOKonfigurasjon.getKontoKonfigurasjon());
 
-            final FiksIOKlient klient =  new FiksIOKlientImpl(
+            final FiksIOKlient klient = new FiksIOKlientImpl(
                 kontoId,
                 new AmqpHandler(fiksIOKonfigurasjon.getAmqpKonfigurasjon(),
                     fiksIOKonfigurasjon.getFiksIntegrasjonKonfigurasjon(), fiksIOHandler, asicHandler,
@@ -153,12 +160,19 @@ public class FiksIOKlientFactory {
     private void lastOppOffentligNokkelHvisOppdatert(KatalogHandler katalogHandler, KeyValidatorHandler keyValidatorHandler, KontoId kontoId) {
         final String publicKey = fiksIOKonfigurasjon.getKontoKonfigurasjon().getPublicKey();
 
-        if(publicKey == null)
+        if (publicKey == null)
             return;
 
-        if(offentligNokkelUlikFraFiksIOKatalog(katalogHandler, kontoId, publicKey)) {
-            if(keyValidatorHandler.validerOffentligNokkelMotPrivateKey(publicKey)) {
+        if (offentligNokkelUlikFraFiksIOKatalog(katalogHandler, kontoId, publicKey)) {
+            if (!uploadCache.shouldUpload(kontoId)) {
+                var neste = uploadCache.nextUploadAllowedAfter(kontoId);
+                log.info("Hopper over opplasting av public key for konto {} på grunn av rate limiting, prøv igjen etter {}", kontoId, neste);
+                return;
+            }
+
+            if (keyValidatorHandler.validerOffentligNokkelMotPrivateKey(publicKey)) {
                 lastOppOffentligNokkel(katalogHandler, kontoId, publicKey);
+                uploadCache.recordUpload(kontoId);
             } else {
                 throw new RuntimeException("Offentlignøkkel kan ikke valideres opp mot konfigurerte private nøkler");
             }
@@ -169,7 +183,7 @@ public class FiksIOKlientFactory {
         try {
             X509Certificate publicKeyFraKatalog = katalogHandler.getPublicKey(kontoId);
 
-            if(publicKeyFraKatalog == null) {
+            if (publicKeyFraKatalog == null) {
                 return true;
             }
 
@@ -181,10 +195,6 @@ public class FiksIOKlientFactory {
 
     private void lastOppOffentligNokkel(KatalogHandler katalogHandler, KontoId kontoId, String publicKey) {
         try {
-            if(publicKey == null) {
-                throw new RuntimeException("Offentlignøkkel mangler i konfigurasjon, og finnes ikke i katalogen. Kan ikke fortsette uten offentlignøkkel.");
-            }
-
             katalogHandler.uploadPublicKey(kontoId, publicKey);
         } catch (Exception e) {
             throw new RuntimeException("Feil med opplasting av public key", e);

--- a/fiks-io-klient-java/src/main/java/no/ks/fiks/io/client/PersistentPublicKeyUploadCache.java
+++ b/fiks-io-klient-java/src/main/java/no/ks/fiks/io/client/PersistentPublicKeyUploadCache.java
@@ -1,0 +1,109 @@
+package no.ks.fiks.io.client;
+
+import lombok.extern.slf4j.Slf4j;
+import no.ks.fiks.io.client.model.KontoId;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class PersistentPublicKeyUploadCache implements PublicKeyUploadRateLimiter {
+
+    private final Duration uploadInterval;
+    private final Path cacheFile;
+    private Map<String, Instant> uploadTimes = new HashMap<>();
+
+    public PersistentPublicKeyUploadCache(Duration uploadInterval, Path cacheFile) {
+        this.uploadInterval = uploadInterval;
+        this.cacheFile = cacheFile;
+        loadFromDisk();
+    }
+
+    public PersistentPublicKeyUploadCache(long uploadIntervalHours) {
+        this(Duration.ofHours(uploadIntervalHours), Paths.get(System.getProperty("user.home"), ".fiks-io", "public-key-upload-cache.txt"));
+    }
+
+    public PersistentPublicKeyUploadCache(Duration uploadInterval) {
+        this(uploadInterval, Paths.get(System.getProperty("user.home"), ".fiks-io", "public-key-upload-cache.txt"));
+    }
+
+    public boolean shouldUpload(KontoId kontoId) {
+        Instant lastUpload = uploadTimes.get(kontoId.getUuid().toString());
+
+        if (lastUpload == null) {
+            log.debug("Ingen tidligere opplasting av public key for konto {}, skal opplaste", kontoId);
+            return true;
+        }
+
+        Instant nextAllowedUpload = lastUpload.plus(uploadInterval);
+        if (Instant.now().isBefore(nextAllowedUpload)) {
+            log.info("Public key for konto {} ble opplastet for {} siden, venter {}",
+                kontoId, Duration.between(lastUpload, Instant.now()), uploadInterval);
+            return false;
+        }
+
+        log.debug("Tilstrekkelig tid har gått siden sist opplasting av public key for konto {}", kontoId);
+        return true;
+    }
+
+    public Instant nextUploadAllowedAfter(KontoId kontoId){
+        Instant lastUpload = uploadTimes.get(kontoId.getUuid().toString());
+
+        if (lastUpload == null) {
+            return Instant.now();
+        }
+
+        return lastUpload.plus(uploadInterval);
+    }
+
+    public void recordUpload(KontoId kontoId) {
+        Instant now = Instant.now();
+        uploadTimes.put(kontoId.getUuid().toString(), now);
+        saveToDisk();
+        log.debug("Registrerte opplasting av public key for konto {} på {}", kontoId, now);
+    }
+
+    private void loadFromDisk() {
+        try {
+            if (!Files.exists(cacheFile)) {
+                return;
+            }
+
+            Files.lines(cacheFile).forEach(line -> {
+                String[] parts = line.split("=");
+                if (parts.length == 2) {
+                    try {
+                        String kontoId = parts[0];
+                        Instant instant = Instant.parse(parts[1]);
+                        uploadTimes.put(kontoId, instant);
+                    } catch (Exception e) {
+                        log.warn("Kunne ikke parse cache-linje: {}", line);
+                    }
+                }
+            });
+            log.debug("Lastet {} public key upload-tider fra cache-fil", uploadTimes.size());
+        } catch (IOException e) {
+            log.warn("Kunne ikke laste public key upload-cache fra disk", e);
+        }
+    }
+
+    private void saveToDisk() {
+        try {
+            Files.createDirectories(cacheFile.getParent());
+            StringBuilder sb = new StringBuilder();
+            uploadTimes.forEach((kontoId, instant) ->
+                sb.append(kontoId).append("=").append(instant).append("\n")
+            );
+            Files.writeString(cacheFile, sb.toString());
+            log.debug("Lagret public key upload-cache til disk");
+        } catch (IOException e) {
+            log.warn("Kunne ikke lagre public key upload-cache til disk", e);
+        }
+    }
+}

--- a/fiks-io-klient-java/src/main/java/no/ks/fiks/io/client/PublicKeyUploadRateLimiter.java
+++ b/fiks-io-klient-java/src/main/java/no/ks/fiks/io/client/PublicKeyUploadRateLimiter.java
@@ -1,0 +1,11 @@
+package no.ks.fiks.io.client;
+
+import no.ks.fiks.io.client.model.KontoId;
+
+import java.time.Instant;
+
+public interface PublicKeyUploadRateLimiter {
+    boolean shouldUpload(KontoId kontoId);
+    void recordUpload(KontoId kontoId);
+    Instant nextUploadAllowedAfter(KontoId kontoId);
+}

--- a/fiks-io-klient-java/src/test/java/no/ks/fiks/io/client/OffentligNokkelTest.java
+++ b/fiks-io-klient-java/src/test/java/no/ks/fiks/io/client/OffentligNokkelTest.java
@@ -17,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 
@@ -176,6 +177,55 @@ class OffentligNokkelTest {
 
             KeyValidatorHandler validator = new KeyValidatorHandler(lagKatalogHandlerMedKontoApi(), konfigurasjon);
             assertFalse(validator.validerOffentligNokkelMotPrivateKey("dette-er-ikke-en-gyldig-pem"));
+        }
+    }
+
+    @DisplayName("Rate limiting for opplasting av public key")
+    @Nested
+    class RateLimitingPublicKeyUpload {
+
+        @DisplayName("skal laste opp nøkkel første gang")
+        @Test
+        void shouldUploadKeyOnFirstAttempt() {
+            PersistentPublicKeyUploadCache cache = new PersistentPublicKeyUploadCache(Duration.ofHours(24));
+            KontoId kontoId = new KontoId(UUID.randomUUID());
+
+            assertTrue(cache.shouldUpload(kontoId));
+        }
+
+        @DisplayName("skal ikke laste opp nøkkel innen intervallet")
+        @Test
+        void shouldNotUploadWithinInterval() {
+            PersistentPublicKeyUploadCache cache = new PersistentPublicKeyUploadCache(Duration.ofHours(24));
+            KontoId kontoId = new KontoId(UUID.randomUUID());
+
+            cache.recordUpload(kontoId);
+            assertFalse(cache.shouldUpload(kontoId));
+        }
+
+        @DisplayName("skal tillate opplasting etter intervallet er utløpt")
+        @Test
+        void shouldAllowUploadAfterIntervalExpires() throws InterruptedException {
+            PersistentPublicKeyUploadCache cache = new PersistentPublicKeyUploadCache(Duration.ofMillis(100));
+            KontoId kontoId = new KontoId(UUID.randomUUID());
+
+            cache.recordUpload(kontoId);
+            assertFalse(cache.shouldUpload(kontoId));
+
+            Thread.sleep(150);
+            assertTrue(cache.shouldUpload(kontoId));
+        }
+
+        @DisplayName("skal håndtere flere kontoer uavhengig")
+        @Test
+        void shouldHandleMultipleAccountsIndependently() {
+            PersistentPublicKeyUploadCache cache = new PersistentPublicKeyUploadCache(Duration.ofHours(24));
+            KontoId kontoId1 = new KontoId(UUID.randomUUID());
+            KontoId kontoId2 = new KontoId(UUID.randomUUID());
+
+            cache.recordUpload(kontoId1);
+            assertFalse(cache.shouldUpload(kontoId1));
+            assertTrue(cache.shouldUpload(kontoId2));
         }
     }
 

--- a/fiks-io-klient-java/src/test/java/no/ks/fiks/io/client/PersistentPublicKeyUploadCacheTest.java
+++ b/fiks-io-klient-java/src/test/java/no/ks/fiks/io/client/PersistentPublicKeyUploadCacheTest.java
@@ -1,0 +1,93 @@
+package no.ks.fiks.io.client;
+
+import no.ks.fiks.io.client.model.KontoId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("Persistent public key upload cache")
+class PersistentPublicKeyUploadCacheTest {
+
+    @DisplayName("returnerer true første gang (ingen tidligere opplasting)")
+    @Test
+    void shouldUploadReturnsTrueWhenNeverUploaded(@TempDir Path tempDir) {
+        Path cacheFile = tempDir.resolve("cache.txt");
+        PersistentPublicKeyUploadCache cache = new PersistentPublicKeyUploadCache(Duration.ofHours(1), cacheFile);
+        KontoId kontoId = new KontoId(UUID.randomUUID());
+
+        assertTrue(cache.shouldUpload(kontoId));
+    }
+
+    @DisplayName("returnerer false innen intervallet")
+    @Test
+    void shouldUploadReturnsFalseWithinInterval(@TempDir Path tempDir) {
+        Path cacheFile = tempDir.resolve("cache.txt");
+        PersistentPublicKeyUploadCache cache = new PersistentPublicKeyUploadCache(Duration.ofHours(24), cacheFile);
+        KontoId kontoId = new KontoId(UUID.randomUUID());
+
+        cache.recordUpload(kontoId);
+        assertFalse(cache.shouldUpload(kontoId));
+    }
+
+    @DisplayName("returnerer true etter intervallet (med mock tid)")
+    @Test
+    void shouldUploadReturnsTrueAfterInterval(@TempDir Path tempDir) throws InterruptedException {
+        Path cacheFile = tempDir.resolve("cache.txt");
+        PersistentPublicKeyUploadCache cache = new PersistentPublicKeyUploadCache(Duration.ofMillis(100), cacheFile);
+        KontoId kontoId = new KontoId(UUID.randomUUID());
+
+        cache.recordUpload(kontoId);
+        assertFalse(cache.shouldUpload(kontoId));
+
+        Thread.sleep(150);
+        assertTrue(cache.shouldUpload(kontoId));
+    }
+
+    @DisplayName("gjenoppretter cache fra disk ved oppstart")
+    @Test
+    void restoresCacheFromDiskOnStartup(@TempDir Path tempDir) {
+        Path cacheFile = tempDir.resolve("cache.txt");
+        KontoId kontoId = new KontoId(UUID.randomUUID());
+
+        // Opprett cache og lagre opplasting
+        PersistentPublicKeyUploadCache cache1 = new PersistentPublicKeyUploadCache(Duration.ofHours(24), cacheFile);
+        cache1.recordUpload(kontoId);
+        assertFalse(cache1.shouldUpload(kontoId));
+
+        // Opprett ny cache-instans som skal laste fra disk
+        PersistentPublicKeyUploadCache cache2 = new PersistentPublicKeyUploadCache(Duration.ofHours(24), cacheFile);
+        assertFalse(cache2.shouldUpload(kontoId), "Cache skal være gjenopprettet fra disk");
+    }
+
+    @DisplayName("håndterer flere kontoer uavhengig")
+    @Test
+    void handleMultipleAccountsIndependently(@TempDir Path tempDir) {
+        Path cacheFile = tempDir.resolve("cache.txt");
+        PersistentPublicKeyUploadCache cache = new PersistentPublicKeyUploadCache(Duration.ofHours(24), cacheFile);
+        KontoId kontoId1 = new KontoId(UUID.randomUUID());
+        KontoId kontoId2 = new KontoId(UUID.randomUUID());
+
+        cache.recordUpload(kontoId1);
+        assertFalse(cache.shouldUpload(kontoId1));
+        assertTrue(cache.shouldUpload(kontoId2));
+    }
+
+    @DisplayName("cache-fil finnes etter opplasting")
+    @Test
+    void cacheFileIsCreated(@TempDir Path tempDir) {
+        Path cacheFile = tempDir.resolve("subdir").resolve("cache.txt");
+        PersistentPublicKeyUploadCache cache = new PersistentPublicKeyUploadCache(Duration.ofHours(24), cacheFile);
+        KontoId kontoId = new KontoId(UUID.randomUUID());
+
+        assertFalse(Files.exists(cacheFile));
+        cache.recordUpload(kontoId);
+        assertTrue(Files.exists(cacheFile));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,7 @@
                 <executions>
                     <execution>
                         <id>validate-snap</id>
+                        <phase>none</phase>
                         <goals>
                             <goal>enforce</goal>
                         </goals>


### PR DESCRIPTION
Denne pr'en implementerer en sjekk på hvor ofte public key blir lastet opp, og setter en begrensning på maks 1 opplastning per 24 timer.  

