### PR TITLE
Disable implisitt kjøring av maven-enforcer-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,7 @@
                 <executions>
                     <execution>
                         <id>validate-snap</id>
+                        <phase>none</phase>
                         <goals>
                             <goal>enforce</goal>
                         </goals>


### PR DESCRIPTION
maven-enforcer-plugin hindrer generering av release, da release-bygg feiler med meldingen 

```
Only SNAPSHOT versions are allowed on non-release builds!
```
